### PR TITLE
Use right order of sr_rpm_package_free in sr_rpm_package_uniq

### DIFF
--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -256,8 +256,8 @@ sr_rpm_package_uniq(struct sr_rpm_package *packages)
             }
             merged->next = loop->next->next;
 
-            sr_rpm_package_free(loop, false);
             sr_rpm_package_free(loop->next, false);
+            sr_rpm_package_free(loop, false);
 
             loop = merged;
         }


### PR DESCRIPTION
The second sr_rpm_package_free() call has been using already freed variable.
