### PR TITLE
Fixes for JVM frames normalization

### DIFF
--- a/lib/normalize.c
+++ b/lib/normalize.c
@@ -481,6 +481,7 @@ sr_normalize_core_thread(struct sr_core_thread *thread)
             is_removable_libstdcpp(frame->function_name, frame->file_name) ||
             is_removable_linux(frame->function_name, frame->file_name) ||
             is_removable_xorg(frame->function_name, frame->file_name) ||
+            is_removable_jvm(frame->function_name, frame->file_name) ||
             is_removable_vim(frame->function_name, frame->file_name);
 
         bool removable_with_above =

--- a/tests/normalize.at
+++ b/tests/normalize.at
@@ -220,7 +220,7 @@ main(void)
   assert(thread.frames == frame3);
   assert(thread.frames->next == NULL);
 
-  sr_gdb_frame_free(frame1);
+  sr_gdb_frame_free(frame3);
   return 0;
 }
 ]])


### PR DESCRIPTION
- fix segfaulting unit test
- normalize core stacktraces too

Related to #128, #129.

Signed-off-by: Martin Milata mmilata@redhat.com
