### PR TITLE
configure: add option for static python module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,15 @@ AC_ARG_ENABLE([python-manpage],
               [enable_python_manpage=yes])
 AM_CONDITIONAL(ENABLE_PYTHON_MANPAGE, [test $enable_python_manpage = yes])
 
+AC_ARG_ENABLE([static-python-module],
+              [AS_HELP_STRING([--enable-static-python-module],
+                              [Compile the python module so that it does not load libsatyr.so
+                               dynamically but includes the object files directly.
+                               Might be needed to use the module on OpenShift.])],
+              [enable_static_python_module=$enableval],
+              [enable_static_python_module=no])
+AM_CONDITIONAL(ENABLE_STATIC_PYTHON_MODULE, [test $enable_static_python_module = yes])
+
 AC_CHECK_LIB([opcodes], [main], [have_libopcodes=yes], [have_libopcodes=no])
 [if test "$have_libopcodes" = "no" -a "$target_cpu" = "x86_64"; then]
     [echo "The libopcodes library was not found in the search path. The core stacktrace support "]

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,5 +1,17 @@
-lib_LTLIBRARIES = libsatyr.la
-libsatyr_la_SOURCES = \
+# NOTE: First, we build so-called 'convenience library' from all sources. IIUC,
+# convenience libraries are something like collection of object files and they
+# are only used at build time, never installed. We then use it to create
+# libsatyr.so (and possibly ../python/_satyr.so).
+#
+# This is needed in order to build satyr python module that does NOT load
+# libsatyr.so dynamically in order to circumvent OpenShift limitation.
+#
+# See following page for description of convenience libraries:
+# https://sourceware.org/autobook/autobook/autobook_92.html
+
+noinst_LTLIBRARIES = libsatyr_conv.la
+
+libsatyr_conv_la_SOURCES = \
 	callgraph.h \
 	cluster.h \
 	disasm.h \
@@ -50,14 +62,19 @@ libsatyr_la_SOURCES = \
 	unstrip.c \
 	utils.c
 
-libsatyr_la_CFLAGS = -Wall -std=gnu99 -D_GNU_SOURCE -I$(top_srcdir)/include $(GLIB_CFLAGS)
-libsatyr_la_LDFLAGS = -version-info 2:0:0 -export-symbols-regex '^sr_' $(GLIB_LIBS)
+libsatyr_conv_la_CFLAGS = -Wall -std=gnu99 -D_GNU_SOURCE -I$(top_srcdir)/include $(GLIB_CFLAGS)
+libsatyr_conv_la_LDFLAGS = $(GLIB_LIBS)
 
 if HAVE_LIBOPCODES
 # Conditional link is required to avoid linking to a library without
 # -fPIC.
-libsatyr_la_LIBADD = -lopcodes
+libsatyr_conv_la_LIBADD = -lopcodes
 endif
+
+lib_LTLIBRARIES = libsatyr.la
+libsatyr_la_SOURCES = 
+libsatyr_la_LIBADD = libsatyr_conv.la
+libsatyr_la_LDFLAGS = -version-info 2:0:0 -export-symbols-regex '^sr_'
 
 # From http://www.seul.org/docs/autotut/
 # Version consists 3 numbers: CURRENT, REVISION, AGE.

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -68,5 +68,13 @@ _satyr_la_CPPFLAGS = \
 _satyr_la_LDFLAGS = \
     -module \
     -avoid-version \
-    -export-symbols-regex init_satyr \
-    ../lib/libsatyr.la
+    -export-symbols-regex init_satyr
+
+# Depending on the configure option, we either link libsatyr.so dynamically (as
+# is usual), or directly include the its object files (by including the
+# convenience library).
+if ENABLE_STATIC_PYTHON_MODULE
+_satyr_la_LIBADD = ../lib/libsatyr_conv.la
+else
+_satyr_la_LIBADD = ../lib/libsatyr.la
+endif


### PR DESCRIPTION
This option, --enable-static-python-module, influences whether
libsatyr.so is linked in statically or dynamically.

Signed-off-by: Martin Milata mmilata@redhat.com
