### PR TITLE
Normalize Red Hat Enterprise Linux OS name

### DIFF
--- a/lib/operating_system.c
+++ b/lib/operating_system.c
@@ -140,17 +140,23 @@ sr_operating_system_parse_etc_system_release(const char *etc_system_release,
     if (!release)
         return false;
 
-    *name = sr_strndup(etc_system_release, release - etc_system_release);
-
-    if (0 == strlen(*name))
-        return false;
-
-    /* make the name all lower case */
-    char *a = *name;
-    while (*a)
+    /* Normal form of Red Hat Enterprise Linux's name is "rhel" */
+    if (strncasecmp("Red Hat Enterprise Linux", etc_system_release, strlen("Red Hat Enterprise Linux")) == 0)
+        *name = sr_strndup("rhel", strlen("rhel"));
+    else
     {
-        *a = tolower(*a);
-        a++;
+        *name = sr_strndup(etc_system_release, release - etc_system_release);
+
+        if (0 == strlen(*name))
+            return false;
+
+        /* make the name all lower case */
+        char *a = *name;
+        while (*a)
+        {
+            *a = tolower(*a);
+            a++;
+        }
     }
 
     const char *version_begin = release + strlen(" release ");

--- a/tests/operating_system.at
+++ b/tests/operating_system.at
@@ -34,7 +34,8 @@ int
 main(void)
 {
     check("Fedora release 16 (Verne)", "fedora", "16");
-    check("Red Hat Enterprise Linux release 6.2", "red hat enterprise linux", "6.2");
+    check("Red Hat Enterprise Linux release 6.2", "rhel", "6.2");
+    check("CentOS release 6.5 (Final) ", "centos", "6.5");
     return 0;
 }
 ]])


### PR DESCRIPTION
All Red Hat Enterprise Linux release names must be 'rhel'

Signed-off-by: Jakub Filak jfilak@redhat.com
