### PR TITLE
unwind: determine shared libs from /proc/PID/maps

### DIFF
--- a/include/core/unwind.h
+++ b/include/core/unwind.h
@@ -33,10 +33,23 @@ sr_parse_coredump(const char *coredump_filename,
                   char **error_message);
 
 struct sr_core_stacktrace *
+sr_parse_coredump_maps(const char *coredump_filename,
+                       const char *executable_filename,
+                       const char *maps_filename,
+                       char **error_message);
+
+struct sr_core_stacktrace *
 sr_core_stacktrace_from_gdb(const char *gdb_output,
                             const char *coredump_filename,
                             const char *executable_filename,
                             char **error_message);
+
+struct sr_core_stacktrace *
+sr_core_stacktrace_from_gdb_maps(const char *gdb_output,
+                                 const char *coredump_filename,
+                                 const char *executable_filename,
+                                 const char *maps_filename,
+                                 char **error_message);
 
 #ifdef __cplusplus
 }

--- a/lib/abrt.c
+++ b/lib/abrt.c
@@ -94,15 +94,17 @@ create_core_stacktrace(const char *directory, const char *gdb_output,
         return NULL;
 
     char *coredump_filename = sr_build_path(directory, "coredump", NULL);
+    char *maps_filename = sr_build_path(directory, "maps", NULL);
 
     struct sr_core_stacktrace *core_stacktrace;
 
     if (gdb_output)
-        core_stacktrace = sr_core_stacktrace_from_gdb(gdb_output,
-                coredump_filename, executable_contents, error_message);
+        core_stacktrace = sr_core_stacktrace_from_gdb_maps(gdb_output,
+                coredump_filename, executable_contents, maps_filename,
+                error_message);
     else
-        core_stacktrace = sr_parse_coredump(coredump_filename,
-                executable_contents, error_message);
+        core_stacktrace = sr_parse_coredump_maps(coredump_filename,
+                executable_contents, maps_filename, error_message);
 
     free(executable_contents);
     free(coredump_filename);

--- a/lib/core_unwind_elfutils.c
+++ b/lib/core_unwind_elfutils.c
@@ -126,9 +126,10 @@ abort:
 }
 
 struct sr_core_stacktrace *
-sr_parse_coredump(const char *core_file,
-                  const char *exe_file,
-                  char **error_msg)
+sr_parse_coredump_maps(const char *core_file,
+                       const char *exe_file,
+                       const char *maps_file,
+                       char **error_msg)
 {
     struct sr_core_stacktrace *stacktrace = NULL;
 
@@ -136,7 +137,7 @@ sr_parse_coredump(const char *core_file,
     if (error_msg)
         *error_msg = NULL;
 
-    struct core_handle *ch = open_coredump(core_file, exe_file, error_msg);
+    struct core_handle *ch = open_coredump(core_file, exe_file, maps_file, error_msg);
     if (!ch)
         goto fail;
 
@@ -185,6 +186,14 @@ sr_parse_coredump(const char *core_file,
 fail:
     core_handle_free(ch);
     return stacktrace;
+}
+
+struct sr_core_stacktrace *
+sr_parse_coredump(const char *core_file,
+                  const char *exe_file,
+                  char **error_msg)
+{
+    return sr_parse_coredump_maps(core_file, exe_file, NULL, error_msg);
 }
 
 #endif /* WITH_LIBDWFL */

--- a/lib/core_unwind_libunwind.c
+++ b/lib/core_unwind_libunwind.c
@@ -127,9 +127,10 @@ get_signal_number_libunwind(struct UCD_info *ui)
 }
 
 struct sr_core_stacktrace *
-sr_parse_coredump(const char *core_file,
-                   const char *exe_file,
-                   char **error_msg)
+sr_parse_coredump_maps(const char *core_file,
+                       const char *exe_file,
+                       const char *maps_file,
+                       char **error_msg)
 {
     struct sr_core_stacktrace *stacktrace = NULL;
 
@@ -137,7 +138,7 @@ sr_parse_coredump(const char *core_file,
     if (error_msg)
         *error_msg = NULL;
 
-    struct core_handle *ch = open_coredump(core_file, exe_file, error_msg);
+    struct core_handle *ch = open_coredump(core_file, exe_file, maps_file, error_msg);
     if (*error_msg)
         return NULL;
 
@@ -203,6 +204,14 @@ fail_destroy_handle:
     core_handle_free(ch);
 
     return stacktrace;
+}
+
+struct sr_core_stacktrace *
+sr_parse_coredump(const char *core_file,
+                  const char *exe_file,
+                  char **error_msg)
+{
+    return sr_parse_coredump_maps(core_file, exe_file, NULL, error_msg);
 }
 
 #endif /* WITH_LIBUNWIND */

--- a/lib/internal_unwind.h
+++ b/lib/internal_unwind.h
@@ -85,7 +85,7 @@ struct core_handle
 /* Gets dwfl handle and executable map data to be used for unwinding. The
  * executable map is only used by libunwind. */
 struct core_handle *
-open_coredump(const char *elf_file, const char *exe_file, char **error_msg);
+open_coredump(const char *elf_file, const char *exe_file, const char *maps_file, char **error_msg);
 
 void
 core_handle_free(struct core_handle *ch);


### PR DESCRIPTION
Until now, elfutils used dynamic loader internal structure to find the shared libraries needed for unwinding and symbol resolution. This structure was sometimes damaged and it seems that getting this info from the maps file is more reliable in some other cases as well (vdso). Related #127.
