### PR TITLE
Add build dependency discovery to autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,1 +1,45 @@
-autoreconf --install --force
+#! /bin/sh
+
+print_help()
+{
+cat << EOH
+Prepares the source tree for configuration
+
+Usage:
+  autogen.sh [sydeps [--install]]
+
+Options:
+
+  sysdeps          prints out all dependencies
+    --install      install all dependencies ('sudo yum install \$DEPS')
+
+EOH
+}
+
+build_depslist()
+{
+    DEPS_LIST=`grep "^\(Build\)\?Requires:" *.spec.in | grep -v "%{name}" | tr -s " " | tr "," "\n" | cut -f2 -d " " | grep -v "^satyr" | sort -u | while read br; do if [ "%" = ${br:0:1} ]; then grep "%define $(echo $br | sed -e 's/%{\(.*\)}/\1/')" *.spec.in | tr -s " " | cut -f4 -d" "; else echo $br ;fi ; done | tr "\n" " "`
+}
+
+case "$1" in
+    "--help"|"-h")
+            print_help
+            exit 0
+        ;;
+    "sysdeps")
+            build_depslist
+
+            if [ "$2" == "--install" ]; then
+                set -x verbose
+                sudo yum install $DEPS_LIST
+                set +x verbose
+            else
+                echo $DEPS_LIST
+            fi
+            exit 0
+        ;;
+    *)
+            echo "Running autoreconf"
+            autoreconf --install --force
+        ;;
+esac


### PR DESCRIPTION
Copypasta'd libreport autogen.sh so that we can install build
dependencies the same way for all three projects.

Signed-off-by: Martin Milata mmilata@redhat.com
