### PR TITLE
Provide sr_parse_coredump_maps even without unwinder

### DIFF
--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -44,9 +44,10 @@
 #if !defined WITH_LIBDWFL && !defined WITH_LIBUNWIND
 
 struct sr_core_stacktrace *
-sr_parse_coredump(const char *coredump_filename,
-                  const char *executable_filename,
-                  char **error_message)
+sr_parse_coredump_maps(const char *coredump_filename,
+                       const char *executable_filename,
+                       const char *maps_filename,
+                       char **error_message)
 {
     *error_message = sr_asprintf("satyr is built without unwind support");
     return NULL;
@@ -495,4 +496,12 @@ sr_core_stacktrace_from_gdb(const char *gdb_output, const char *core_file,
                             const char *exe_file, char **error_msg)
 {
     return sr_core_stacktrace_from_gdb_maps(gdb_output, core_file, exe_file, NULL, error_msg);
+}
+
+struct sr_core_stacktrace *
+sr_parse_coredump(const char *core_file,
+                  const char *exe_file,
+                  char **error_msg)
+{
+    return sr_parse_coredump_maps(core_file, exe_file, NULL, error_msg);
 }

--- a/lib/core_unwind_elfutils.c
+++ b/lib/core_unwind_elfutils.c
@@ -188,12 +188,4 @@ fail:
     return stacktrace;
 }
 
-struct sr_core_stacktrace *
-sr_parse_coredump(const char *core_file,
-                  const char *exe_file,
-                  char **error_msg)
-{
-    return sr_parse_coredump_maps(core_file, exe_file, NULL, error_msg);
-}
-
 #endif /* WITH_LIBDWFL */

--- a/lib/core_unwind_libunwind.c
+++ b/lib/core_unwind_libunwind.c
@@ -206,12 +206,4 @@ fail_destroy_handle:
     return stacktrace;
 }
 
-struct sr_core_stacktrace *
-sr_parse_coredump(const char *core_file,
-                  const char *exe_file,
-                  char **error_msg)
-{
-    return sr_parse_coredump_maps(core_file, exe_file, NULL, error_msg);
-}
-
 #endif /* WITH_LIBUNWIND */


### PR DESCRIPTION
Consistent with the sr_parse_coredump stub function. (Implementation
note: the sr_parse_coredump wrapper was moved to core_unwind.c in order
not to have it duplicated three times.)

Related to #127.

Signed-off-by: Martin Milata mmilata@redhat.com
