### PR TITLE
Fix parsing of invalid syntaxt Python exceptions

### DIFF
--- a/tests/python/python.py
+++ b/tests/python/python.py
@@ -143,6 +143,44 @@ class TestPythonStacktrace(BindingsTestCase):
     def test_hash(self):
         self.assertHashable(self.trace)
 
+    def test_invalid_syntax_current_file(self):
+        trace = load_input_contents('../python_stacktraces/python-04')
+        trace = satyr.PythonStacktrace(trace)
+
+        self.assertEqual(len(trace.frames), 1)
+        self.assertEqual(trace.exception_name, 'SyntaxError')
+
+        f = trace.frames[0]
+        self.assertEqual(f.file_name, '/usr/bin/python3-mako-render')
+        self.assertEqual(f.function_name, "syntax")
+        self.assertEqual(f.file_line, 43)
+        self.assertEqual(f.line_contents, 'print render(data, kw)')
+        self.assertTrue(f.special_function)
+        self.assertFalse(f.special_file)
+
+    def test_invalid_syntax_imported_file(self):
+        trace = load_input_contents('../python_stacktraces/python-05')
+        trace = satyr.PythonStacktrace(trace)
+
+        self.assertEqual(len(trace.frames), 2)
+        self.assertEqual(trace.exception_name, 'SyntaxError')
+
+        f = trace.frames[1]
+        self.assertEqual(f.file_name, '/usr/bin/will_python_raise')
+        self.assertEqual(f.function_name, "module")
+        self.assertEqual(f.file_line, 2)
+        self.assertEqual(f.line_contents, 'import report')
+        self.assertTrue(f.special_function)
+        self.assertFalse(f.special_file)
+
+        f = trace.frames[0]
+        self.assertEqual(f.file_name, '/usr/lib64/python2.7/site-packages/report/__init__.py')
+        self.assertEqual(f.function_name, "syntax")
+        self.assertEqual(f.file_line, 15)
+        self.assertEqual(f.line_contents, 'def foo(:')
+        self.assertTrue(f.special_function)
+        self.assertFalse(f.special_file)
+
 class TestPythonFrame(BindingsTestCase):
     def setUp(self):
         self.frame = satyr.PythonStacktrace(contents).frames[-1]

--- a/tests/python_stacktraces/python-04
+++ b/tests/python_stacktraces/python-04
@@ -1,0 +1,6 @@
+invalid syntax (python3-mako-render, line 43)
+
+  File "/usr/bin/python3-mako-render", line 43
+    print render(data, kw)
+               ^
+SyntaxError: invalid syntax

--- a/tests/python_stacktraces/python-05
+++ b/tests/python_stacktraces/python-05
@@ -1,0 +1,16 @@
+will_python_raise:2:<module>:  File "/usr/lib64/python2.7/site-packages/report/__init__.py", line 15
+
+Traceback (most recent call last):
+  File "/usr/bin/will_python_raise", line 2, in <module>
+    import report
+  File "/usr/lib64/python2.7/site-packages/report/__init__.py", line 15
+    def foo(:
+            ^
+SyntaxError: invalid syntax
+
+Local variables in innermost frame:
+__builtins__: <module '__builtin__' (built-in)>
+__name__: '__main__'
+__file__: '/usr/bin/will_python_raise'
+__doc__: None
+__package__: None


### PR DESCRIPTION
I am not sure how to fill function_name. InvalidSyntax exception have only one frame and that frame does not have file. The patch set special_function to true and leaves function_name empty (NULL), but exporting to JSON adds 'module' to function_name.
