### PR TITLE
core_unwind: Make sure there's always a file_name

### DIFF
--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -107,7 +107,7 @@ find_elf_core (Dwfl_Module *mod, void **userdata, const char *modname,
     {
         int fd = open(executable_file, O_RDONLY);
         if (fd < 0)
-            return -1;
+            goto fail;
 
         *file_name = realpath(executable_file, NULL);
         *elfp = elf_begin(fd, ELF_C_READ, NULL);
@@ -115,7 +115,7 @@ find_elf_core (Dwfl_Module *mod, void **userdata, const char *modname,
         {
             warn("Unable to open executable '%s': %s", executable_file,
                  elf_errmsg(-1));
-            return -1;
+            goto fail;
         }
 
         ret = fd;
@@ -126,6 +126,10 @@ find_elf_core (Dwfl_Module *mod, void **userdata, const char *modname,
                                      file_name, elfp);
     }
 
+    if (*file_name == NULL)
+        *file_name = strdup(modname);
+
+fail:
     return ret;
 }
 


### PR DESCRIPTION
Otherwise the server validation fails. Use module name if there's
no canonical path as is the case for linux-gate.so.1 without kernel
debuginfo installed after 3.16 x86 VDSO rework.

Closes abrt/abrt#826

Signed-off-by: Lubomir Rintel lkundrak@v3.sk
