### PR TITLE
unwind: fix unwinding of VDSO frames on i386

### DIFF
--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -110,7 +110,7 @@ find_elf_core (Dwfl_Module *mod, void **userdata, const char *modname,
             return -1;
 
         *file_name = realpath(executable_file, NULL);
-        *elfp = elf_begin(fd, ELF_C_READ, NULL);
+        *elfp = elf_begin(fd, ELF_C_READ_MMAP, NULL);
         if (*elfp == NULL)
         {
             warn("Unable to open executable '%s': %s", executable_file,


### PR DESCRIPTION
May or may not be elfutils bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1129756

Fixes #163.

Signed-off-by: Martin Milata mmilata@redhat.com
