### PR TITLE
python: make Java Frame's interface generic

### DIFF
--- a/python/py_java_frame.c
+++ b/python/py_java_frame.c
@@ -61,7 +61,8 @@ GSOFF_END
 static PyGetSetDef
 frame_getset[] =
 {
-    SR_ATTRIBUTE_STRING(name,         "Fully qualified domain name (string)"                                  ),
+    SR_ATTRIBUTE_STRING_R("function_name", name, "Fully qualified method/exception name (string)"             ),
+    SR_ATTRIBUTE_STRING(name,         "Fully qualified method/exception name (string)"                        ),
     SR_ATTRIBUTE_STRING(file_name,    "File name (string)"                                                    ),
     SR_ATTRIBUTE_UINT32(file_line,    "File line (positive integer)"                                          ),
     SR_ATTRIBUTE_STRING(class_path,   "Class path (string)"                                                   ),

--- a/tests/python/java.py
+++ b/tests/python/java.py
@@ -218,6 +218,9 @@ class TestJavaFrame(BindingsTestCase):
     def test_hash(self):
         self.assertHashable(self.frame)
 
+    def test_sanity(self):
+        self.assertEqual(self.frame.name, self.frame.function_name)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
All satyr's frame structures must have 'function_name' member.

Signed-off-by: Jakub Filak jfilak@redhat.com
