### PR TITLE
java: ignore suppressed exceptions

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -378,6 +378,9 @@ sr_skip_whitespace(const char *s);
 char *
 sr_skip_non_whitespace(const char *s);
 
+bool
+sr_skip_to_next_line_location(const char **s, int *line, int *column);
+
 /**
  * Emit a string of hex representation of bytes.
  */

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -656,6 +656,22 @@ sr_skip_non_whitespace(const char *s)
     return (char *) s;
 }
 
+bool
+sr_skip_to_next_line_location(const char **s, int *line, int *column)
+{
+    *column += sr_skip_char_cspan(s, "\n");
+
+    if (*s && **s == '\n')
+    {
+        *column = 0;
+        (*line)++;
+        (*s)++;
+        return true;
+    }
+
+    return false;
+}
+
 char *
 sr_bin2hex(char *dst, const char *str, int count)
 {

--- a/tests/java_stacktraces/java-04
+++ b/tests/java_stacktraces/java-04
@@ -1,0 +1,185 @@
+Exception in thread "main" java.lang.RuntimeException: yes
+	at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+	at WontCatchSuppressedException.main(WontCatchSuppressedException.java:35)
+Caused by: java.lang.RuntimeException: yes
+	at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+	at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+	... 1 more
+	Suppressed: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+		at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+		... 1 more
+	Caused by: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+		... 3 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 3 more
+		Caused by: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+			... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 3 more
+		Caused by: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+			... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+	Caused by: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+		... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+	Suppressed: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+		at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+		... 1 more
+	Caused by: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+		... 3 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 3 more
+		Caused by: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+			... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 3 more
+		Caused by: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+			... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+			Suppressed: java.lang.RuntimeException: no
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+				at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+				at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+				... 5 more
+	Caused by: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+		... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+Caused by: java.lang.RuntimeException: yes
+	at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+	at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+	... 2 more
+	Suppressed: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+		at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+		... 2 more
+	Caused by: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+		... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+	Suppressed: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:29)
+		at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+		... 2 more
+	Caused by: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+		... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+		Suppressed: java.lang.RuntimeException: no
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+			at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+			at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+			... 4 more
+Caused by: java.lang.RuntimeException: yes
+	at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+	at WontCatchSuppressedException.die(WontCatchSuppressedException.java:27)
+	... 3 more
+	Suppressed: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+		at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+		... 3 more
+	Suppressed: java.lang.RuntimeException: no
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:23)
+		at WontCatchSuppressedException.close(WontCatchSuppressedException.java:16)
+		at WontCatchSuppressedException.die(WontCatchSuppressedException.java:28)
+		... 3 more

--- a/tests/python/java.py
+++ b/tests/python/java.py
@@ -152,6 +152,18 @@ class TestJavaStacktrace(BindingsTestCase):
     def test_hash(self):
         self.assertHashable(self.trace)
 
+    def test_suppressed(self):
+        contents = load_input_contents('../java_stacktraces/java-04')
+        trace = satyr.JavaStacktrace(contents)
+
+        names = 4*['java.lang.RuntimeException', 'WontCatchSuppressedException.die', 'WontCatchSuppressedException.die']
+        names[-1] = 'WontCatchSuppressedException.main'
+        msgs = 4*['yes', None, None]
+
+        for frame, name, msg in zip(trace.threads[0].frames, names, msgs):
+            self.assertEqual(frame.name, name)
+            self.assertEqual(frame.message, msg)
+
 class TestJavaThread(BindingsTestCase):
     def setUp(self):
         self.thread = satyr.JavaStacktrace(contents).threads[0]


### PR DESCRIPTION
Java exceptions can form a tree - every exception can have reference to
exception that caused it and to a list of exceptions that were
suppressed during handling[1]. We cannot take the suppressed exceptions
into account without changing the uReport format, therefore this commit
makes the java parser ignore them.

[1] http://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html

Fixes rhbz#1034857.

Signed-off-by: Martin Milata mmilata@redhat.com
