### PR TITLE
gdb: quality frame has to have file name

### DIFF
--- a/lib/gdb_thread.c
+++ b/lib/gdb_thread.c
@@ -170,10 +170,11 @@ sr_gdb_thread_quality_counts(struct sr_gdb_thread *thread,
     while (frame)
     {
         *all_count += 1;
+        bool has_name = (frame->function_name
+            && 0 != strcmp(frame->function_name, "??"));
+        bool has_source = (frame->source_file && *frame->source_file);
 
-        if (frame->signal_handler_called ||
-            (frame->function_name
-             && 0 != strcmp(frame->function_name, "??")))
+        if (frame->signal_handler_called || (has_name && has_source))
         {
             *ok_count += 1;
         }


### PR DESCRIPTION
With MiniDebugInfo, almost every frame has function_name present - but
we want more. With full debuginfo we also get file name and line number.
The file name has to be present now in order to count the frame as good
in stacktrace quality computation.

Closes abrt/abrt#851.
Related to rhbz#1149431.

Signed-off-by: Martin Milata mmilata@redhat.com
