### PR TITLE
unwind: fix unwinding of VDSO frames on i386 more

### DIFF
--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -202,7 +202,7 @@ open_coredump(const char *elf_file, const char *exe_file, char **error_msg)
         goto fail_free;
     }
 
-    ch->eh = elf_begin(ch->fd, ELF_C_READ, NULL);
+    ch->eh = elf_begin(ch->fd, ELF_C_READ_MMAP, NULL);
     if (ch->eh == NULL)
     {
         set_error_elf("elf_begin");


### PR DESCRIPTION
It looks like the fix (for rhbz#1129756, #163) in
2543c337e633fefe55c123b2f375a47fda8a884d was incomplete.

Fixes rhbz#1191586.

Signed-off-by: Martin Milata <mmilata@redhat.com>