### PR TITLE
unwind: include filename for VDSOs

### DIFF
--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -294,12 +294,12 @@ resolve_frame(Dwfl *dwfl, Dwarf_Addr ip, bool minus_one)
             sr_bin2hex(frame->build_id, (const char *)build_id_bits, ret);
         }
 
-        if (dwfl_module_info(mod, NULL, &start, NULL, NULL, NULL,
-                             &filename, NULL) != NULL)
+        char *modname = dwfl_module_info(mod, NULL, &start, NULL, NULL, NULL,
+                                         &filename, NULL);
+        if (modname)
         {
             frame->build_id_offset = ip - start;
-            if (filename)
-                frame->file_name = sr_strdup(filename);
+            frame->file_name = filename ? sr_strdup(filename) : sr_strdup(modname);
         }
 
         funcname = dwfl_module_addrname(mod, (GElf_Addr)ip_adjusted);


### PR DESCRIPTION
Virtual DSOs do not have backing file on the filesystem. However
elfutils knows the name of the shared object (e.g. linux-gate.so.1) and
this is what we can use if the filename cannot be determined.

Fixes rhbz#1191586, related to #163.

Signed-off-by: Martin Milata <mmilata@redhat.com>