### PR TITLE
core_unwind: fix the missing frame build_id and file_name

### DIFF
--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -285,8 +285,13 @@ resolve_frame(Dwfl *dwfl, Dwarf_Addr ip, bool minus_one)
         int ret;
         const unsigned char *build_id_bits;
         const char *filename, *funcname;
-        GElf_Addr bid_addr;
+        GElf_Addr bias, bid_addr;
         Dwarf_Addr start;
+
+        /* Initialize the module's main Elf for dwfl_module_build_id and dwfl_module_info */
+        /* No need to deallocate the variable 'bias' and the return value.*/
+        if (NULL == dwfl_module_getelf(mod, &bias))
+            warn("The module's main Elf was not found");
 
         ret = dwfl_module_build_id(mod, &build_id_bits, &bid_addr);
         if (ret > 0)
@@ -297,6 +302,7 @@ resolve_frame(Dwfl *dwfl, Dwarf_Addr ip, bool minus_one)
 
         const char *modname = dwfl_module_info(mod, NULL, &start, NULL, NULL, NULL,
                                                &filename, NULL);
+
         if (modname)
         {
             frame->build_id_offset = ip - start;


### PR DESCRIPTION
The documentation of dwfl_module_build_id() says:

  This returns 0 when the module's main ELF file has not yet been loaded
  and its build ID bits were not reported.  To ensure the ID is always
  returned when determinable, call dwfl_module_getelf first.

  /usr/include/elfutils/libdwfl.h

ABRT upstream commit 88c6b3683a129c0e369071204b29fbca94772d3b verifies
this patch.

Discovered by Richard Marko <rmarko@redhat.com>
Resolved by Mark Wielaard <mjw@redhat.com>

Signed-off-by: Jakub Filak <jfilak@redhat.com>