### PR TITLE
Fix compile warnings.

### DIFF
--- a/include/core/frame.h
+++ b/include/core/frame.h
@@ -85,7 +85,7 @@ struct sr_core_frame
  * calling the function sr_core_frame_free().
  */
 struct sr_core_frame *
-sr_core_frame_new();
+sr_core_frame_new(void);
 
 /**
  * Initializes all members of the frame structure to their default

--- a/include/core/stacktrace.h
+++ b/include/core/stacktrace.h
@@ -69,7 +69,7 @@ struct sr_core_stacktrace
  * calling the function sr_core_stacktrace_free().
  */
 struct sr_core_stacktrace *
-sr_core_stacktrace_new();
+sr_core_stacktrace_new(void);
 
 /**
  * Initializes all members of the stacktrace structure to their default

--- a/include/core/thread.h
+++ b/include/core/thread.h
@@ -67,7 +67,7 @@ struct sr_core_thread
  * calling the function sr_core_thread_free().
  */
 struct sr_core_thread *
-sr_core_thread_new();
+sr_core_thread_new(void);
 
 /**
  * Initializes all members of the thread to default values.

--- a/include/gdb/frame.h
+++ b/include/gdb/frame.h
@@ -36,6 +36,8 @@ extern "C" {
 struct sr_strbuf;
 struct sr_location;
 
+typedef uint64_t sr_gdb_frame_address_t;
+
 /**
  * @brief A function call of a GDB-produced stack trace.
  *
@@ -87,7 +89,7 @@ struct sr_gdb_frame
      * address is unknown. Address is unknown when the frame
      * represents inlined function.
      */
-    uint64_t address;
+    sr_gdb_frame_address_t address;
 
     /**
      * A library name or NULL.
@@ -108,7 +110,7 @@ struct sr_gdb_frame
  * calling the function sr_gdb_frame_free().
  */
 struct sr_gdb_frame *
-sr_gdb_frame_new();
+sr_gdb_frame_new(void);
 
 /**
  * Initializes all members of the frame structure to their default

--- a/include/gdb/sharedlib.h
+++ b/include/gdb/sharedlib.h
@@ -58,7 +58,7 @@ struct sr_gdb_sharedlib
  * calling the function sr_gdb_sharedlib_free().
  */
 struct sr_gdb_sharedlib *
-sr_gdb_sharedlib_new();
+sr_gdb_sharedlib_new(void);
 
 /**
  * Initializes all members of the sharedlib to default values.  No

--- a/include/gdb/stacktrace.h
+++ b/include/gdb/stacktrace.h
@@ -86,7 +86,7 @@ struct sr_gdb_stacktrace
  * calling the function sr_gdb_stacktrace_free().
  */
 struct sr_gdb_stacktrace *
-sr_gdb_stacktrace_new();
+sr_gdb_stacktrace_new(void);
 
 /**
  * Initializes all members of the stacktrace structure to their default

--- a/include/gdb/thread.h
+++ b/include/gdb/thread.h
@@ -74,7 +74,7 @@ struct sr_gdb_thread
  * calling the function sr_gdb_thread_free().
  */
 struct sr_gdb_thread *
-sr_gdb_thread_new();
+sr_gdb_thread_new(void);
 
 /**
  * Initializes all members of the thread to default values.

--- a/include/java/frame.h
+++ b/include/java/frame.h
@@ -98,7 +98,7 @@ struct sr_java_frame
  * calling the function sr_java_frame_free().
  */
 struct sr_java_frame *
-sr_java_frame_new();
+sr_java_frame_new(void);
 
 /**
  * Creates and initializes a new exception in frame structure.
@@ -107,7 +107,7 @@ sr_java_frame_new();
  * calling the function sr_java_frame_free().
  */
 struct sr_java_frame *
-sr_java_frame_new_exception();
+sr_java_frame_new_exception(void);
 
 /**
  * Initializes all members of the frame structure to their default

--- a/include/java/stacktrace.h
+++ b/include/java/stacktrace.h
@@ -54,7 +54,7 @@ struct sr_java_stacktrace
  * calling the function sr_java_stacktrace_free().
  */
 struct sr_java_stacktrace *
-sr_java_stacktrace_new();
+sr_java_stacktrace_new(void);
 
 /**
  * Initializes all members of the stacktrace structure to their default

--- a/include/java/thread.h
+++ b/include/java/thread.h
@@ -72,7 +72,7 @@ struct sr_java_thread
  * calling the function sr_java_thread_free().
  */
 struct sr_java_thread *
-sr_java_thread_new();
+sr_java_thread_new(void);
 
 /**
  * Initializes all members of the thread to default values.

--- a/include/koops/frame.h
+++ b/include/koops/frame.h
@@ -111,7 +111,7 @@ struct sr_koops_frame
  * calling the function sr_koops_frame_free().
  */
 struct sr_koops_frame *
-sr_koops_frame_new();
+sr_koops_frame_new(void);
 
 /**
  * Initializes all members of the frame structure to their default

--- a/include/koops/stacktrace.h
+++ b/include/koops/stacktrace.h
@@ -101,7 +101,7 @@ struct sr_koops_stacktrace
  * calling the function sr_koops_stacktrace_free().
  */
 struct sr_koops_stacktrace *
-sr_koops_stacktrace_new();
+sr_koops_stacktrace_new(void);
 
 /**
  * Initializes all members of the stacktrace structure to their default

--- a/include/operating_system.h
+++ b/include/operating_system.h
@@ -42,7 +42,7 @@ struct sr_operating_system
 };
 
 struct sr_operating_system *
-sr_operating_system_new();
+sr_operating_system_new(void);
 
 void
 sr_operating_system_init(struct sr_operating_system *operating_system);

--- a/include/python/frame.h
+++ b/include/python/frame.h
@@ -64,7 +64,7 @@ struct sr_python_frame
  * calling the function sr_python_frame_free().
  */
 struct sr_python_frame *
-sr_python_frame_new();
+sr_python_frame_new(void);
 
 /**
  * Initializes all members of the frame structure to their default

--- a/include/python/stacktrace.h
+++ b/include/python/stacktrace.h
@@ -54,7 +54,7 @@ struct sr_python_stacktrace
  * calling the function sr_python_stacktrace_free().
  */
 struct sr_python_stacktrace *
-sr_python_stacktrace_new();
+sr_python_stacktrace_new(void);
 
 /**
  * Initializes all members of the stacktrace structure to their default

--- a/include/report.h
+++ b/include/report.h
@@ -63,7 +63,7 @@ struct sr_report
 };
 
 struct sr_report *
-sr_report_new();
+sr_report_new(void);
 
 void
 sr_report_init(struct sr_report *report);

--- a/include/rpm.h
+++ b/include/rpm.h
@@ -78,7 +78,7 @@ struct sr_rpm_package
 };
 
 struct sr_rpm_package *
-sr_rpm_package_new();
+sr_rpm_package_new(void);
 
 void
 sr_rpm_package_init(struct sr_rpm_package *package);
@@ -192,7 +192,7 @@ sr_rpm_package_parse_nevra(const char *text,
                            char **architecture);
 
 struct sr_rpm_consistency *
-sr_rpm_consistency_new();
+sr_rpm_consistency_new(void);
 
 void
 sr_rpm_consistency_init(struct sr_rpm_consistency *consistency);

--- a/include/ruby/frame.h
+++ b/include/ruby/frame.h
@@ -58,7 +58,7 @@ struct sr_ruby_frame
 };
 
 struct sr_ruby_frame *
-sr_ruby_frame_new();
+sr_ruby_frame_new(void);
 
 void
 sr_ruby_frame_init(struct sr_ruby_frame *frame);

--- a/include/ruby/stacktrace.h
+++ b/include/ruby/stacktrace.h
@@ -42,7 +42,7 @@ struct sr_ruby_stacktrace
 };
 
 struct sr_ruby_stacktrace *
-sr_ruby_stacktrace_new();
+sr_ruby_stacktrace_new(void);
 
 void
 sr_ruby_stacktrace_init(struct sr_ruby_stacktrace *stacktrace);

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -55,7 +55,7 @@ struct sr_strbuf
  * calling the function sr_strbuf_free().
  */
 struct sr_strbuf *
-sr_strbuf_new();
+sr_strbuf_new(void);
 
 /**
  * Initializes all members of the strbuf structure to their default

--- a/python/py_common.c
+++ b/python/py_common.c
@@ -164,7 +164,7 @@ sr_py_getter_uint64(PyObject *self, void *data)
         = MEMB_T(uint64_t, MEMB(self, gsoff->c_struct_offset), gsoff->member_offset);
 
     /* If the attribute is UINT64_MAX, return None. */
-    if (num == -1)
+    if (num == (uint64_t) -1)
         Py_RETURN_NONE;
 
     return PyLong_FromUnsignedLongLong(num);

--- a/python/py_gdb_frame.c
+++ b/python/py_gdb_frame.c
@@ -227,7 +227,7 @@ sr_py_gdb_frame_str(PyObject *self)
         sr_strbuf_append_str(buf, "unknown function");
     else
         sr_strbuf_append_strf(buf, "function %s", this->frame->function_name);
-    if (this->frame->address != -1)
+    if (this->frame->address != (sr_py_gdb_frame_address_t) -1)
         sr_strbuf_append_strf(buf, " @ 0x%016"PRIx64, this->frame->address);
     if (this->frame->library_name)
         sr_strbuf_append_strf(buf, " (%s)", this->frame->library_name);

--- a/python/py_gdb_frame.h
+++ b/python/py_gdb_frame.h
@@ -31,8 +31,11 @@ extern "C" {
 
 #include <Python.h>
 #include <structmember.h>
+#include "gdb/frame.h"
 
 PyTypeObject sr_py_gdb_frame_type;
+
+typedef sr_gdb_frame_address_t sr_py_gdb_frame_address_t;
 
 /* The beginning of this structure has to have the same layout as
  * sr_py_base_frame.

--- a/python/py_gdb_stacktrace.c
+++ b/python/py_gdb_stacktrace.c
@@ -481,7 +481,7 @@ sr_py_gdb_stacktrace_find_address(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "l", &address))
         return NULL;
 
-    if (address == -1)
+    if (address == (unsigned long long) -1)
         Py_RETURN_NONE;
 
     int i;

--- a/python/py_metrics.c
+++ b/python/py_metrics.c
@@ -503,7 +503,7 @@ sr_py_distances_part_reduce(PyObject *self, PyObject *args)
         if (!dist_list)
             return NULL;
 
-        int i;
+        unsigned int i;
         for (i = 0; i < part->len; i++)
         {
             PyObject *f = PyFloat_FromDouble((double)part->distances[i]);

--- a/python/py_ruby_frame.c
+++ b/python/py_ruby_frame.c
@@ -182,7 +182,7 @@ sr_py_ruby_frame_str(PyObject *self)
     {
         sr_strbuf_append_str(buf, ":in `");
 
-        int i;
+        unsigned int i;
         for (i = 0; i < this->frame->rescue_level; i++)
         {
             sr_strbuf_append_str(buf, "rescue in ");


### PR DESCRIPTION
include: function declaration isn’t a prototype
python: signed versus unsigned comparison