### PR TITLE
elfutils: run hook unwinding under unprivileged user

### DIFF
--- a/include/abrt.h
+++ b/include/abrt.h
@@ -28,6 +28,9 @@ extern "C" {
 #include <stdbool.h>
 #include <sys/types.h>
 
+/* Forward declaration to avoid the need to include core/unwind.h */
+struct sr_core_stracetrace_unwind_state;
+
 bool
 sr_abrt_print_report_from_dir(const char *directory,
                               char **error_message);
@@ -43,6 +46,18 @@ sr_abrt_create_core_stacktrace_from_gdb(const char *directory,
                                         const char *gdb_output,
                                         bool hash_fingerprints,
                                         char **error_message);
+
+
+struct sr_core_stracetrace_unwind_state *
+sr_abrt_get_core_stacktrace_from_core_hook_prepare(pid_t thread_id,
+                                                   char **error_message);
+
+char *
+sr_abrt_get_core_stacktrace_from_core_hook_generate(pid_t thread_id,
+                                                    const char *executable,
+                                                    int signum,
+                                                    struct sr_core_stracetrace_unwind_state *state,
+                                                    char **error_message);
 
 char *
 sr_abrt_get_core_stacktrace_from_core_hook(pid_t thread_id,

--- a/include/core/unwind.h
+++ b/include/core/unwind.h
@@ -28,6 +28,7 @@ extern "C" {
 
 struct sr_core_stacktrace;
 struct sr_gdb_stacktrace;
+struct sr_core_stracetrace_unwind_state;
 
 struct sr_core_stacktrace *
 sr_parse_coredump(const char *coredump_filename,
@@ -55,6 +56,19 @@ sr_core_stacktrace_from_core_hook(pid_t thread_id,
                                   const char *executable_filename,
                                   int signum,
                                   char **error_message);
+
+struct sr_core_stracetrace_unwind_state *
+sr_core_stacktrace_from_core_hook_prepare(pid_t tid, char **error_msg);
+
+struct sr_core_stacktrace *
+sr_core_stacktrace_from_core_hook_generate(pid_t tid,
+                                           const char *executable,
+                                           int signum,
+                                           struct sr_core_stracetrace_unwind_state *state,
+                                           char **error_msg);
+
+void
+sr_core_stacktrace_unwind_state_free(struct sr_core_stracetrace_unwind_state *state);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
We need to divide the unwinding into too steps because we want to run
elfutils under unprivileged users in abrt-hook-ccpp.

This commit splits the unwinding into prepare and generate parts. The
prepare part includes attaching the process using PTRACE - this part
must be run under privileged users. The generate part includes unwinding.

With some modifications to elfutils, we might be able to run all
elfutils function under an unprivileged user.

Signed-off-by: Adam Sulc <xmineral@seznam.cz>
Signed-off-by: Jakub Filak <jfilak@redhat.com>