### PR TITLE
Improve truncated backtrace format for python and core

### DIFF
--- a/lib/core_frame.c
+++ b/lib/core_frame.c
@@ -328,19 +328,20 @@ void
 sr_core_frame_append_to_str(struct sr_core_frame *frame,
                             struct sr_strbuf *dest)
 {
+    if (frame->file_name)
+    {
+        const char *basename = strrchr(frame->file_name, '/');
+        sr_strbuf_append_strf(dest, "[%s]", basename ? ++basename : frame->file_name);
+    }
+
     if (frame->function_name)
     {
-        sr_strbuf_append_str(dest, frame->function_name);
+        sr_strbuf_append_strf(dest, " %s", frame->function_name);
     }
     else
     {
-        sr_strbuf_append_strf(dest, "%s+%"PRIu64, frame->build_id,
+        sr_strbuf_append_strf(dest, " %s+%"PRIu64, frame->build_id,
                               frame->build_id_offset);
-    }
-
-    if (frame->file_name)
-    {
-        sr_strbuf_append_strf(dest, " in %s", frame->file_name);
     }
 }
 

--- a/lib/python_frame.c
+++ b/lib/python_frame.c
@@ -433,14 +433,9 @@ void
 sr_python_frame_append_to_str(struct sr_python_frame *frame,
                               struct sr_strbuf *dest)
 {
-    sr_strbuf_append_strf(dest, "%s%s%s",
-                          (frame->special_function ? "<" : ""),
-                          (frame->function_name ? frame->function_name : "??"),
-                          (frame->special_function ? ">" : ""));
-
     if (frame->file_name)
     {
-        sr_strbuf_append_strf(dest, " in %s%s%s",
+        sr_strbuf_append_strf(dest, "[%s%s%s",
                               (frame->special_file ? "<" : ""),
                               frame->file_name,
                               (frame->special_file ? ">" : ""));
@@ -449,7 +444,14 @@ sr_python_frame_append_to_str(struct sr_python_frame *frame,
         {
             sr_strbuf_append_strf(dest, ":%"PRIu32, frame->file_line);
         }
+
+        sr_strbuf_append_str(dest, "]");
     }
+
+    sr_strbuf_append_strf(dest, " %s%s%s",
+                          (frame->special_function ? "<" : ""),
+                          (frame->function_name ? frame->function_name : "??"),
+                          (frame->special_function ? ">" : ""));
 }
 
 static void

--- a/tests/core_frame.at
+++ b/tests/core_frame.at
@@ -123,7 +123,7 @@ main(void)
   sr_frame_append_to_str((struct sr_frame*)frame, strbuf);
   char *res = sr_strbuf_free_nobuf(strbuf);
 
-  assert(0 == strcmp(res, "test1 in executable1"));
+  assert(0 == strcmp(res, "[executable1] test1"));
   free(res);
 
   return 0;

--- a/tests/python/core.py
+++ b/tests/python/core.py
@@ -6,10 +6,10 @@ from test_helpers import *
 contents = load_input_contents('../json_files/core-01')
 threads_expected = 2
 frames_expected = 6
-expected_short_text = '''#1 raise in /usr/lib64/libc-2.15.so
-#2 abort in /usr/lib64/libc-2.15.so
-#3 92ebaf825e4f492952c45189cb9ffc6541f8599b+1123 in /usr/bin/will_abort
-#4 __libc_start_main in /usr/lib64/libc-2.15.so
+expected_short_text = '''#1 [libc-2.15.so] raise
+#2 [libc-2.15.so] abort
+#3 [will_abort] 92ebaf825e4f492952c45189cb9ffc6541f8599b+1123
+#4 [libc-2.15.so] __libc_start_main
 '''
 
 class TestCoreStacktrace(BindingsTestCase):

--- a/tests/python/python.py
+++ b/tests/python/python.py
@@ -6,12 +6,12 @@ from test_helpers import *
 path = '../python_stacktraces/python-01'
 contents = load_input_contents(path)
 frames_expected = 11
-expected_short_text = '''#1 _getPackage in /home/anonymized/PackageKit/helpers/yum/yumBackend.py:2534
-#2 updateProgress in /usr/share/PackageKit/helpers/yum/yumBackend.py:2593
-#3 _do_start in /usr/share/PackageKit/helpers/yum/yumBackend.py:2551
-#4 start in /usr/lib/python2.6/site-packages/urlgrabber/progress.py:129
-#5 downloadPkgs in /usr/lib/yum-plugins/presto.py:419
-#6 predownload_hook in /usr/lib/yum-plugins/presto.py:577
+expected_short_text = '''#1 [/home/anonymized/PackageKit/helpers/yum/yumBackend.py:2534] _getPackage
+#2 [/usr/share/PackageKit/helpers/yum/yumBackend.py:2593] updateProgress
+#3 [/usr/share/PackageKit/helpers/yum/yumBackend.py:2551] _do_start
+#4 [/usr/lib/python2.6/site-packages/urlgrabber/progress.py:129] start
+#5 [/usr/lib/yum-plugins/presto.py:419] downloadPkgs
+#6 [/usr/lib/yum-plugins/presto.py:577] predownload_hook
 '''
 
 class TestPythonStacktrace(BindingsTestCase):


### PR DESCRIPTION
Old core truncated backtrace format:
 #1 crash in /usr/bin/will_segfault
 #2 varargs in /usr/bin/will_segfault
 #3 f in /usr/bin/will_segfault
 #4 callback in /usr/bin/will_segfault
 #5 call_me_back in /usr/lib64/libwillcrash.so.0.0.0

New core truncated backtrace format:
 #1 [will_segfault] crash
 #2 [will_segfault] varargs
 #3 [will_segfault] f
 #4 [will_segfault] callback
 #5 [libwillcrash.so.0.0.0] call_me_back

Old python truncated backtrace format:
 #1 crash in /home/mhabrnal/a.py:4
 #2 a in /home/mhabrnal/a.py:7
 #3 recursion in /home/mhabrnal/a.py:13
 #4 recursion in /home/mhabrnal/a.py:11
 #5 recursion in /home/mhabrnal/a.py:11

New python truncated backtrace format:
 #1 [/home/mhabrnal/a.py:4] crash
 #2 [/home/mhabrnal/a.py:7] a
 #3 [/home/mhabrnal/a.py:13] recursion
 #4 [/home/mhabrnal/a.py:11] recursion
 #5 [/home/mhabrnal/a.py:11] recursion

Basename is in Python truncated backtraces along with its path because
there can be __init__.py file and we want to know where is the file
placed.

Fixes: #253

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>