### PR TITLE
Allow rpm to be optional at build time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,16 @@ if test "$elfutils_unwinder" != "1"; then
 fi
 
 # rpm
-AC_CHECK_LIB([rpm], [main])
+AC_ARG_WITH([rpm],
+            [AS_HELP_STRING([--with-rpm],
+                            [Build with rpm support.])],
+            [with_rpm=$withval],
+            [with_rpm=no])
+[if test "$with_rpm" = "yes"]
+[then]
+    PKG_CHECK_MODULES([RPM], [rpm])
+    AC_DEFINE(HAVE_LIBRPM, [], [Have rpm support.])
+[fi]
 
 # c++ symbol demangling
 AC_CHECK_LIB([stdc++], [__cxa_demangle], [], [echo "error: stdc++ library not found"; exit 1])

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -67,8 +67,8 @@ libsatyr_conv_la_SOURCES = \
 	unstrip.c \
 	utils.c
 
-libsatyr_conv_la_CFLAGS = -Wall -Wformat=2 -std=gnu99 -D_GNU_SOURCE -I$(top_srcdir)/include $(GLIB_CFLAGS)
-libsatyr_conv_la_LDFLAGS = $(GLIB_LIBS)
+libsatyr_conv_la_CFLAGS = -Wall -Wformat=2 -std=gnu99 -D_GNU_SOURCE -I$(top_srcdir)/include $(GLIB_CFLAGS) $(RPM_CFLAGS)
+libsatyr_conv_la_LDFLAGS = $(GLIB_LIBS) $(RPM_LIBS)
 
 lib_LTLIBRARIES = libsatyr.la
 libsatyr_la_SOURCES = 


### PR DESCRIPTION
This was already mostly done with the HAVE_LIBRPM define already being
used in lib/rpm.c. Just finish the plumbing so that we don't always
require rpm at configure time when we weren't going to use it anyway.

I am not sure if and how this affects the spec file so I didn't change it. If you want me to update that in any way, I would be happy to resubmit this.