### PR TITLE
elfutils: Add missing stubs from earlier commit

### DIFF
--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -57,6 +57,24 @@ sr_parse_coredump(const char *coredump_filename,
 
 #if (!defined WITH_LIBDWFL || !defined PTRACE_SEIZE)
 
+struct sr_core_stracetrace_unwind_state *
+sr_core_stacktrace_from_core_hook_prepare(pid_t thread_id, char **error_message)
+{
+    *error_message = sr_asprintf("satyr is built without live process unwind support");
+    return NULL;
+}
+
+struct sr_core_stacktrace *
+sr_core_stacktrace_from_core_hook_generate(pid_t thread_id,
+                                           const char *executable_filename,
+                                           int signum,
+                                           struct sr_core_stracetrace_unwind_state *state,
+                                           char **error_message)
+{
+    *error_message = sr_asprintf("satyr is built without live process unwind support");
+    return NULL;
+}
+
 struct sr_core_stacktrace *
 sr_core_stacktrace_from_core_hook(pid_t thread_id,
                                   const char *executable_filename,


### PR DESCRIPTION
Commit f749d97f060e3c287eb700636790d61337b73eae added new functions
*_core_hook_prepare and *_core_hook_generate to replace a single
function *_core_hook. The *_core_hook was already stubbed out when
WITH_LIBDWFL or PTRACE_SEIZE was not defined, but the new commit did not
add matching stubs for the new functions that replaced it.