### PR TITLE
Introduce 'unpackaged' field in uReport

### DIFF
--- a/include/abrt.h
+++ b/include/abrt.h
@@ -80,8 +80,8 @@ sr_abrt_create_core_stacktrace_from_core_hook(const char *directory,
 struct sr_rpm_package *
 sr_abrt_parse_dso_list(const char *text);
 
-struct sr_rpm_package *
-sr_abrt_rpm_packages_from_dir(const char *directory,
+int
+sr_abrt_rpm_packages_from_dir(const char *directory, struct sr_rpm_package **packages,
                               char **error_message);
 
 struct sr_operating_system *

--- a/include/abrt.h
+++ b/include/abrt.h
@@ -80,8 +80,8 @@ sr_abrt_create_core_stacktrace_from_core_hook(const char *directory,
 struct sr_rpm_package *
 sr_abrt_parse_dso_list(const char *text);
 
-int
-sr_abrt_rpm_packages_from_dir(const char *directory, struct sr_rpm_package **packages,
+struct sr_rpm_package *
+sr_abrt_rpm_packages_from_dir(const char *directory,
                               char **error_message);
 
 struct sr_operating_system *

--- a/include/rpm.h
+++ b/include/rpm.h
@@ -173,9 +173,9 @@ char *
 sr_rpm_package_to_json(struct sr_rpm_package *package,
                        bool recursive);
 
-struct sr_rpm_package *
-sr_rpm_package_from_json(struct sr_json_value *list, bool recursive,
-                         char **error_message);
+int
+sr_rpm_package_from_json(struct sr_rpm_package **rpm_package, struct sr_json_value *list,
+                         bool recursive, char **error_message);
 
 bool
 sr_rpm_package_parse_nvr(const char *text,

--- a/lib/abrt.c
+++ b/lib/abrt.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <limits.h>
 #include <errno.h>
+#include <unistd.h>
 
 static char*
 file_contents(const char *directory, const char *file, char **error_message)
@@ -303,11 +304,11 @@ strip_newline(char *str)
         *n = '\0';
 }
 
-struct sr_rpm_package *
-sr_abrt_rpm_packages_from_dir(const char *directory,
-                              char **error_message)
+static struct sr_rpm_package *
+rpm_pkg_from_dir(struct sr_rpm_package *packages,
+                 const char *directory,
+                 char **error_message)
 {
-
     char *epoch_str = file_contents(directory, "pkg_epoch", error_message);
     if (!epoch_str)
     {
@@ -321,7 +322,6 @@ sr_abrt_rpm_packages_from_dir(const char *directory,
     }
     free(epoch_str);
 
-    struct sr_rpm_package *packages = sr_rpm_package_new();
 
     packages->epoch = (uint32_t)epoch;
     packages->name = file_contents(directory, "pkg_name", error_message);
@@ -344,6 +344,14 @@ sr_abrt_rpm_packages_from_dir(const char *directory,
     strip_newline(packages->release);
     strip_newline(packages->architecture);
 
+    return packages;
+}
+
+static struct sr_rpm_package *
+rpm_dso_list_from_dir(struct sr_rpm_package *packages,
+                      const char *directory,
+                      char **error_message)
+{
     char *dso_list_contents = file_contents(directory, "dso_list",
                                             error_message);
     if (dso_list_contents)
@@ -359,6 +367,45 @@ sr_abrt_rpm_packages_from_dir(const char *directory,
         }
 
         free(dso_list_contents);
+    }
+
+    return packages;
+}
+
+static bool
+is_packaged(const char *directory)
+{
+    char *path = sr_build_path(directory, "package", NULL);
+
+    bool retval = false;
+    if (access(path, F_OK) == 0)
+        retval = true;
+
+    free(path);
+    return retval;
+}
+
+struct sr_rpm_package *
+sr_abrt_rpm_packages_from_dir(const char *directory,
+                              char **error_message)
+{
+    struct sr_rpm_package *packages = NULL;
+
+    /* if unpackaged do not attach package data */
+    if (is_packaged(directory))
+    {
+        packages = sr_rpm_package_new();
+        packages = rpm_pkg_from_dir(packages, directory, error_message);
+        if (!packages)
+            return NULL;
+    }
+
+    /* if dso_list doesn't exist, do not attach it */
+    if (file_exist(directory, "dso_list"))
+    {
+        packages = rpm_dso_list_from_dir(packages, directory, error_message);
+        if (!packages)
+            return NULL;
     }
 
     return packages;
@@ -523,10 +570,11 @@ sr_abrt_report_from_dir(const char *directory,
     report->component_name = file_contents(directory, "component", error_message);
 
     /* RPM packages. */
+    *error_message = NULL;
     report->rpm_packages = sr_abrt_rpm_packages_from_dir(
         directory, error_message);
 
-    if (!report->rpm_packages)
+    if (!report->rpm_packages && *error_message)
     {
         sr_report_free(report);
         return NULL;

--- a/lib/abrt.c
+++ b/lib/abrt.c
@@ -373,9 +373,9 @@ rpm_dso_list_from_dir(struct sr_rpm_package *packages,
 }
 
 static bool
-is_packaged(const char *directory)
+file_exist(const char *directory, const char *filename)
 {
-    char *path = sr_build_path(directory, "package", NULL);
+    char *path = sr_build_path(directory, filename, NULL);
 
     bool retval = false;
     if (access(path, F_OK) == 0)
@@ -385,30 +385,34 @@ is_packaged(const char *directory)
     return retval;
 }
 
-struct sr_rpm_package *
-sr_abrt_rpm_packages_from_dir(const char *directory,
+static bool
+is_packaged(const char *directory)
+{
+    return file_exist(directory, "package");
+}
+
+int
+sr_abrt_rpm_packages_from_dir(const char *directory, struct sr_rpm_package **packages,
                               char **error_message)
 {
-    struct sr_rpm_package *packages = NULL;
-
     /* if unpackaged do not attach package data */
     if (is_packaged(directory))
     {
-        packages = sr_rpm_package_new();
-        packages = rpm_pkg_from_dir(packages, directory, error_message);
-        if (!packages)
-            return NULL;
+        *packages = sr_rpm_package_new();
+        *packages = rpm_pkg_from_dir(*packages, directory, error_message);
+        if (!*packages)
+            return -1;
     }
 
     /* if dso_list doesn't exist, do not attach it */
     if (file_exist(directory, "dso_list"))
     {
-        packages = rpm_dso_list_from_dir(packages, directory, error_message);
-        if (!packages)
-            return NULL;
+        *packages = rpm_dso_list_from_dir(*packages, directory, error_message);
+        if (!*packages)
+            return -2;
     }
 
-    return packages;
+    return 0;
 }
 
 static char *
@@ -491,6 +495,35 @@ finito:
     return result;
 }
 
+static char *
+get_component(const char *directory,
+              char **error_message)
+{
+    if (is_packaged(directory))
+        return file_contents(directory, "component", error_message);
+
+    /* create component from executable basename concatenated with '-unpackaged' str */
+    if (file_exist(directory, "executable"))
+    {
+        char *executable = file_contents(directory, "executable", error_message);
+        if (executable)
+        {
+            const char *basename = strrchr(executable, '/');
+            if (basename)
+                ++basename;
+            else
+                basename = executable;
+
+            char *artificial_component = sr_asprintf("%s-unpackaged", basename);
+
+            free(executable);
+            return artificial_component;
+        }
+    }
+
+    return NULL;
+}
+
 struct sr_operating_system *
 sr_abrt_operating_system_from_dir(const char *directory,
                                   char **error_message)
@@ -567,14 +600,10 @@ sr_abrt_report_from_dir(const char *directory,
     }
 
     /* Component name. */
-    report->component_name = file_contents(directory, "component", error_message);
+    report->component_name = get_component(directory, error_message);
 
     /* RPM packages. */
-    *error_message = NULL;
-    report->rpm_packages = sr_abrt_rpm_packages_from_dir(
-        directory, error_message);
-
-    if (!report->rpm_packages && *error_message)
+    if (sr_abrt_rpm_packages_from_dir(directory, &report->rpm_packages, error_message) < 0 )
     {
         sr_report_free(report);
         return NULL;

--- a/lib/report.c
+++ b/lib/report.c
@@ -255,6 +255,9 @@ sr_report_to_json(struct sr_report *report)
 
         free(rpms_str_indented);
     }
+    /* If there is no package, attach empty list (packages is a mandatory field) */
+    else
+        sr_strbuf_append_strf(strbuf, ",   \"packages\": []\n");
 
     /* Custom entries.
      *    "auth" : {   "foo": "blah"
@@ -349,8 +352,7 @@ sr_report_from_json(struct sr_json_value *root, char **error_message)
     if (packages)
     {
         /* In the future, we'll choose the parsing function according to OS here. */
-        report->rpm_packages = sr_rpm_package_from_json(packages, true, error_message);
-        if (!report->rpm_packages)
+        if (sr_rpm_package_from_json(&report->rpm_packages, packages, true, error_message) < 0)
             goto fail;
     }
 
@@ -441,7 +443,6 @@ struct sr_report *
 sr_report_from_json_text(const char *report, char **error_message)
 {
     struct sr_json_value *json_root = sr_json_parse(report, error_message);
-
     if (!json_root)
         return NULL;
 

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -615,18 +615,19 @@ fail:
     return NULL;
 }
 
-struct sr_rpm_package *
-sr_rpm_package_from_json(struct sr_json_value *json, bool recursive, char **error_message)
+int
+sr_rpm_package_from_json(struct sr_rpm_package **rpm_package, struct sr_json_value *json,
+                         bool recursive, char **error_message)
 {
     if (!recursive)
     {
-        return single_rpm_pacakge_from_json(json, error_message);
+        *rpm_package = single_rpm_pacakge_from_json(json, error_message);
+        return 0;
     }
     else
     {
         if (!JSON_CHECK_TYPE(json, SR_JSON_ARRAY, "package list"))
-            return NULL;
-
+            return -1;
         struct sr_rpm_package *result = NULL;
 
         struct sr_json_value *pkg_json;
@@ -639,13 +640,12 @@ sr_rpm_package_from_json(struct sr_json_value *json, bool recursive, char **erro
             result = sr_rpm_package_append(result, pkg);
         }
 
-        if (result == NULL && error_message)
-            *error_message = sr_strdup("No RPM packages present");
-        return result;
+        *rpm_package = result;
+        return 0;
 
 fail:
         sr_rpm_package_free(result, true);
-        return NULL;
+        return -2;
     }
 }
 


### PR DESCRIPTION
We want to allow sending uReports for crashes from unpackaged
executables. To recognize such uReports we introduce 'unpackaged'
field.

We do this for customers who deploy own FAF server for binaries
which are not shiped within rpms.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>