### PR TITLE
makefile: add make release-* subcommands

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,3 +39,34 @@ rpm: dist-xz satyr.spec
 	rpmbuild $(RPM_DIRS) -ba satyr.spec
 srpm: dist-xz satyr.spec
 	rpmbuild $(RPM_DIRS) -bs satyr.spec
+
+UPLOAD_URL ?= localhost
+
+upload: dist
+	scp $(distdir).tar.gz $$(test -n "$$UPLOAD_LOGIN" && echo "$$UPLOAD_LOGIN@")$(UPLOAD_URL)
+
+.PHONY: release-minor
+release-minor:
+	OLD_VER=$$(git describe --tags --match "[0-9]*" --abbrev=0 HEAD 2>/dev/null); \
+	MAJOR_VER=$$(echo $$OLD_VER | cut -d. -f 1); \
+	MINOR_VER=$$(echo $$OLD_VER | cut -d. -f 2); \
+	$(MAKE) release OLD_VER=$$OLD_VER NEW_VER="$$MAJOR_VER.$$((MINOR_VER+1))"
+
+.PHONY: release-major
+release-major:
+	OLD_VER=$$(git describe --tags --match "[0-9]*" --abbrev=0 HEAD 2>/dev/null); \
+	MAJOR_VER=$$(echo $$OLD_VER | cut -d. -f 1); \
+	$(MAKE) release OLD_VER=$$OLD_VER NEW_VER="$$((MAJOR_VER+1)).0"
+
+.PHONY: release
+release:
+	echo "* $$(LANG='en_US.UTF-8' date +'%a %b %d %Y') $$(git config --get user.name) <$$(git config --get user.email)> $$NEW_VER-1" | sort > /tmp/changelog.tmp; \
+	git log --oneline $$OLD_VER..HEAD | awk '{$$1=""; if (a[$$0]++ == 0) print "-" $$0} END {print ""}' | grep -v -e "- Merge" -e "- testsuite:" -e "- make:" >> /tmp/changelog.tmp; \
+	sed "$$(grep -n %changelog satyr.spec.in | cut -f1 -d: | head -1)"'r /tmp/changelog.tmp' -i satyr.spec.in; \
+	sed 's|DEF_VER=.*$$|DEF_VER='$$NEW_VER'|' -i gen-version; \
+	git add gen-version satyr.spec.in; \
+	git commit -s -m "Release $$NEW_VER"; \
+	git tag "$$NEW_VER"; \
+	echo -n "$$NEW_VER" > satyr-version
+	autoconf --force
+	$(MAKE) dist

--- a/RELEASE
+++ b/RELEASE
@@ -1,53 +1,30 @@
 Releasing a new version of satyr
 --------------------------------
 
-1. Check that all changes from all work computers are commited. Then
+1. Check that all changes from all work computers are committed. Then
 check, that the local clone of the program is up-to-date:
 $ git status
 $ git pull
 
 
-2. Increase a version number in gen-version script (option DEF_VER=x.y).
-(x.y = the new version number)
-
-
-3. Check all the changes in the ChangeLog since the last release, and
-if any change modifies the satyr library interface, increase the
+2. If any change modifies the satyr library interface, increase the
 CURRENT number in lib/Makefile.am:
 libsatyr_la_LDFLAGS = -version-info 2:1:0
-                                       ^
-Document this change in the ChangeLog:
-* lib/Makefile.am (libsatyr_la_LDFLAGS): Increase CURRENT
-library version number, as the library interface changed since the
-last release.
 
 
-4. Update NEWS file to include user-visible, important informations
+3. Update NEWS file to include user-visible, important informations
 about the new release. Provide the date of the release (Released
-YYYY-MM-DD. Document this change in the ChangeLog:
+YYYY-MM-DD).
 * NEWS: Document recent changes.
 
 
-5. Read and update the README file, if you see that some change made
+4. Read and update the README file, if you see that some change made
 since the last release expanded the project scope, or added
-significant new functionality. Document this change in the ChangeLog.
+significant new functionality.
 
 
-6. Read and update the man page, to be sure that it's synchronized
-with the code. Document changes in the ChangeLog.
+5. Read and update the man page, to be sure that it's synchronized
+with the code.
 
 
-7. Commit all the new changes. Tag the new release using `git tag x.y`
-(x.y = the new version number). Push the changes to the git server
-using `git push && git push --tags`.
-
-
-Creating a satyr-x.y.tar.xz
----------------------------
-1. Set the new version to satyr-version and run autoconf
-(x.y = the new version number):
-`echo -n x.y > satyr-version && autoconf --force`
-
-
-2. Create satyr-x.y.tar.xz
-`make dist-xz`
+6. Run make release-{minor,major}, when all changes are committed.


### PR DESCRIPTION
Adds make release-* commands to the Makefile.am (as abrt and libreport has) to ease and speedup
release process of satyr.
Update RELEASE notes, remove ChangeLog from it, since it is no more
present in the tree.