### PR TITLE
testsuite: Correct syntax for gdb backtrace command

### DIFF
--- a/tests/core_stacktrace.at
+++ b/tests/core_stacktrace.at
@@ -281,7 +281,7 @@ get_backtrace(const char *core_file, const char *executable)
   args[i++] = (char*)"-ex";
   args[i++] = sr_asprintf("core-file %s", core_file);
   args[i++] = (char*)"-ex";
-  args[i++] = (char*)"thread apply all -ascending backtrace 1024 full";
+  args[i++] = (char*)"thread apply all -ascending backtrace full 1024";
   args[i++] = (char*)"-ex";
   args[i++] = (char*)"info sharedlib";
   args[i++] = (char*)"-ex";


### PR DESCRIPTION
The test failed on rawhide (gdb v8.1.50) with error message:
"A syntax error in expression, near `full'."

According to the GDB documentation the correct syntax for backtrace
command is `backtrace [full] n`.

- https://sourceware.org/gdb/onlinedocs/gdb/Backtrace.html

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>