### PR TITLE
pkg-config-ify the build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,9 +143,19 @@ AM_CONDITIONAL(WITH_PYTHON3, [test $with_python3 = yes])
 AC_CHECK_LIB([bfd], [main])
 AC_CHECK_LIB([dl], [main])
 
-PKG_CHECK_MODULES([LIBDW], [libdw], [AC_DEFINE([HAVE_LIBDW], [], [libdw found])], [true])
-PKG_CHECK_MODULES([LIBELF], [libelf], [AC_DEFINE([HAVE_LIBELF], [], [libelf found])], [true])
-PKG_CHECK_MODULES([LIBUNWIND], [libunwind-coredump], [AC_DEFINE([HAVE_LIBUNWIND], [], [libunwind found])], [true])
+PKG_CHECK_MODULES([LIBDW], [libdw], [AC_DEFINE([HAVE_LIBDW], [], [libdw found])])
+PKG_CHECK_MODULES([LIBELF], [libelf], [AC_DEFINE([HAVE_LIBELF], [], [libelf found])])
+
+AC_ARG_WITH([unwinder],
+            [AS_HELP_STRING([--with-unwinder=@<:@elfutils/libunwind@:>@],
+                            [call stack unwinder to use @<:@default=elfutils@:>@])],
+            [],
+            [with_unwinder=elfutils])
+AS_IF([test "x$with_unwinder" = "xlibunwind"],
+      [PKG_CHECK_MODULES([LIBUNWIND],
+                         [libunwind-coredump],
+                         [AC_DEFINE([WITH_LIBUNWIND], [], [use libunwind for unwinding])])],
+      [AC_DEFINE([WITH_LIBDWFL], [], [use elfutils for unwinding])])
 
 # rpm
 AC_ARG_WITH([rpm],

--- a/configure.ac
+++ b/configure.ac
@@ -141,27 +141,11 @@ AM_CONDITIONAL(WITH_PYTHON3, [test $with_python3 = yes])
 
 # Check BFD
 AC_CHECK_LIB([bfd], [main])
-
-# elfutils
-AC_CHECK_HEADERS([dwarf.h elfutils/libdw.h elfutils/libdwfl.h gelf.h libelf.h])
-AC_CHECK_LIB([elf], [main])
-# dwfl is actually part of libdw, at least on Fedora
-AC_CHECK_LIB([dw], [main])
-AC_CHECK_LIB([dwfl], [main])
 AC_CHECK_LIB([dl], [main])
-elfutils_unwinder=0
-AC_CHECK_FUNC(dwfl_getthreads,
-  AC_DEFINE(HAVE_DWFL_NEXT_THREAD, [], [Have function dwfl_getthreads for coredump unwinding])
-  elfutils_unwinder=1
-)
 
-# libunwind
-if test "$elfutils_unwinder" != "1"; then
-  AC_CHECK_HEADERS([libunwind-coredump.h])
-  AC_CHECK_LIB([unwind], [main])
-  AC_CHECK_LIB([unwind-generic], [main])
-  AC_CHECK_LIB([unwind-coredump], [main])
-fi
+PKG_CHECK_MODULES([LIBDW], [libdw], [AC_DEFINE([HAVE_LIBDW], [], [libdw found])], [true])
+PKG_CHECK_MODULES([LIBELF], [libelf], [AC_DEFINE([HAVE_LIBELF], [], [libelf found])], [true])
+PKG_CHECK_MODULES([LIBUNWIND], [libunwind-coredump], [AC_DEFINE([HAVE_LIBUNWIND], [], [libunwind found])], [true])
 
 # rpm
 AC_ARG_WITH([rpm],

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -67,8 +67,19 @@ libsatyr_conv_la_SOURCES = \
 	unstrip.c \
 	utils.c
 
-libsatyr_conv_la_CFLAGS = -Wall -Wformat=2 -std=gnu99 -D_GNU_SOURCE -I$(top_srcdir)/include $(GLIB_CFLAGS) $(RPM_CFLAGS)
-libsatyr_conv_la_LDFLAGS = $(GLIB_LIBS) $(RPM_LIBS)
+libsatyr_conv_la_CFLAGS = \
+	-Wall -Wformat=2 -std=gnu99 -D_GNU_SOURCE -I$(top_srcdir)/include \
+	$(GLIB_CFLAGS) \
+	$(LIBDW_CFLAGS) \
+	$(LIBELF_CFLAGS) \
+	$(LIBUNWIND_CFLAGS) \
+	$(RPM_CFLAGS)
+libsatyr_conv_la_LIBADD = \
+	$(GLIB_LIBS) \
+	$(LIBDW_LIBS) \
+	$(LIBELF_LIBS) \
+	$(LIBUNWIND_LIBS) \
+	$(RPM_LIBS)
 
 lib_LTLIBRARIES = libsatyr.la
 libsatyr_la_SOURCES = 

--- a/lib/elves.c
+++ b/lib/elves.c
@@ -22,7 +22,7 @@
 #include "config.h"
 #include "strbuf.h"
 
-#if (defined HAVE_DWARF_H && defined HAVE_ELFUTILS_LIBDW_H && defined HAVE_LIBELF_H && defined HAVE_GELF_H && defined HAVE_LIBELF)
+#if (defined HAVE_LIBDW && defined HAVE_LIBELF)
 #  define WITH_ELFUTILS
 #endif
 

--- a/lib/internal_unwind.h
+++ b/lib/internal_unwind.h
@@ -27,11 +27,11 @@
 #include "config.h"
 
 /* define macros indicating what unwinder are we using */
-#if (defined HAVE_LIBELF_H && defined HAVE_GELF_H && defined HAVE_LIBELF && defined HAVE_LIBDW && defined HAVE_ELFUTILS_LIBDWFL_H && defined HAVE_DWFL_NEXT_THREAD)
+#if (defined HAVE_LIBDW && defined HAVE_LIBELF)
 #  define WITH_LIBDWFL
 #endif
 
-#if !defined WITH_LIBDWFL && (defined HAVE_LIBUNWIND && defined HAVE_LIBUNWIND_COREDUMP && defined HAVE_LIBUNWIND_GENERIC && defined HAVE_LIBUNWIND_COREDUMP_H && defined HAVE_LIBELF_H && defined HAVE_GELF_H && defined HAVE_LIBELF && defined HAVE_LIBDW && defined HAVE_ELFUTILS_LIBDWFL_H)
+#if !defined WITH_LIBDWFL && (defined HAVE_LIBDW && defined HAVE_LIBELF && defined HAVE_LIBUNWIND)
 #  define WITH_LIBUNWIND
 #endif
 

--- a/lib/internal_unwind.h
+++ b/lib/internal_unwind.h
@@ -26,15 +26,6 @@
 
 #include "config.h"
 
-/* define macros indicating what unwinder are we using */
-#if (defined HAVE_LIBDW && defined HAVE_LIBELF)
-#  define WITH_LIBDWFL
-#endif
-
-#if !defined WITH_LIBDWFL && (defined HAVE_LIBDW && defined HAVE_LIBELF && defined HAVE_LIBUNWIND)
-#  define WITH_LIBUNWIND
-#endif
-
 /* Error/warning reporting macros. Allows the error reporting code to be less
  * verbose with the restrictions that:
  *  - pointer to error message pointer must be always named "error_msg"


### PR DESCRIPTION
See commits, but mostly it’s cleaning up checks for obsolete libraries and minimizing auto-detection, which is morally and otherwise reprehensible and broken.