### PR TITLE
style: Various fixes suggested by Clang

### DIFF
--- a/include/core/frame.h
+++ b/include/core/frame.h
@@ -50,6 +50,9 @@ struct sr_core_frame
      * method from null class pointer (address is a low number --
      * offset to the class).
      *
+     * The address might also be unknown, in which case this field is
+     * equal to UINT64_MAX = 2^64 - 1.
+     *
      * Some programs generate machine code during runtime (JavaScript
      * engines, JVM, the Gallium llvmpipe driver).
      */

--- a/lib/core_frame.c
+++ b/lib/core_frame.c
@@ -25,6 +25,7 @@
 #include "thread.h"
 #include "stacktrace.h"
 #include "internal_utils.h"
+#include <limits.h>
 #include <string.h>
 
 /* Method table */
@@ -270,7 +271,7 @@ sr_core_frame_to_json(struct sr_core_frame *frame)
 {
     struct sr_strbuf *strbuf = sr_strbuf_new();
 
-    if (frame->address != -1)
+    if (frame->address != ULONG_MAX)
     {
         sr_strbuf_append_strf(strbuf,
                               ",   \"address\": %"PRIu64"\n",
@@ -284,7 +285,7 @@ sr_core_frame_to_json(struct sr_core_frame *frame)
         sr_strbuf_append_str(strbuf, "\n");
     }
 
-    if (frame->build_id_offset != -1)
+    if (frame->build_id_offset != ULONG_MAX)
     {
         sr_strbuf_append_strf(strbuf,
                               ",   \"build_id_offset\": %"PRIu64"\n",

--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -351,8 +351,7 @@ get_signal_number(Elf *e, const char *elf_file)
     }
 
     /* Go through phdrs, look for prstatus note */
-    int i;
-    for (i = 0; i < nphdr; i++)
+    for (size_t i = 0; i < nphdr; i++)
     {
         GElf_Phdr phdr;
         if (gelf_getphdr(e, i, &phdr) != &phdr)

--- a/lib/distance.c
+++ b/lib/distance.c
@@ -25,8 +25,8 @@
 #include "sha1.h"
 #include "gdb/thread.h"
 #include "internal_utils.h"
-#include <stdlib.h>
 #include <assert.h>
+#include <stdint.h>
 #include <string.h>
 
 float
@@ -199,8 +199,8 @@ distance_levenshtein(struct sr_thread *thread1,
     int n = frame_count2 + 1;
 
     // store only two last rows and columns instead of whole 2D array
-    SR_ASSERT(n <= SIZE_MAX - 1);
-    SR_ASSERT(m <= SIZE_MAX - (n + 1));
+    SR_ASSERT(n <= INT32_MAX - 1);
+    SR_ASSERT(m <= INT32_MAX - (n + 1));
     int *dist = sr_malloc_array(sizeof(int), m + n + 1);
     int *dist1 = sr_malloc_array(sizeof(int), m + n + 1);
 

--- a/lib/elves.c
+++ b/lib/elves.c
@@ -571,7 +571,7 @@ sr_elf_get_eh_frame(const char *filename,
         return NULL;
     }
 
-    uint64_t exec_base = -1;
+    uint64_t exec_base = UINT64_MAX;
     int i;
     for (i = 0; i < phnum; i++)
     {
@@ -593,7 +593,7 @@ sr_elf_get_eh_frame(const char *filename,
         }
     }
 
-    if (-1 == exec_base)
+    if (exec_base == UINT64_MAX)
     {
         *error_message = sr_asprintf("Can't determine executable base for %s",
                                      filename);

--- a/lib/elves.c
+++ b/lib/elves.c
@@ -481,7 +481,6 @@ read_cie(Dwarf_CFI_Entry *cfi,
 static uint64_t
 fde_read_address(const uint8_t *p, unsigned len)
 {
-    int i;
     union {
         uint8_t b[8];
         /* uint16_t n2; */
@@ -490,7 +489,7 @@ fde_read_address(const uint8_t *p, unsigned len)
     } u;
     u.n8 = 0;
 
-    for (i = 0; i < len; i++)
+    for (unsigned i = 0; i < len; i++)
         u.b[i] = *p++;
 
     return (len == 4 ? (uint64_t)u.n4 : u.n8);
@@ -572,8 +571,7 @@ sr_elf_get_eh_frame(const char *filename,
     }
 
     uint64_t exec_base = UINT64_MAX;
-    int i;
-    for (i = 0; i < phnum; i++)
+    for (unsigned i = 0; i < phnum; i++)
     {
         GElf_Phdr phdr;
         if (gelf_getphdr(elf, i, &phdr) != &phdr)

--- a/lib/gdb_frame.c
+++ b/lib/gdb_frame.c
@@ -282,7 +282,7 @@ sr_gdb_frame_append_to_str(struct sr_gdb_frame *frame,
         if (frame->function_name)
             sr_strbuf_append_str(str, " at");
         sr_strbuf_append_strf(str, " %s", frame->source_file);
-        if (frame->source_line != -1)
+        if (frame->source_line != UINT32_MAX)
             sr_strbuf_append_strf(str, ":%"PRIu32, frame->source_line);
     }
 

--- a/lib/gdb_sharedlib.c
+++ b/lib/gdb_sharedlib.c
@@ -106,7 +106,7 @@ sr_gdb_sharedlib_find_address(struct sr_gdb_sharedlib *first,
 {
     struct sr_gdb_sharedlib *tmp = first;
 
-    if (address == -1)
+    if (address == UINT64_MAX)
         return NULL;
 
     while (tmp)

--- a/lib/gdb_stacktrace.c
+++ b/lib/gdb_stacktrace.c
@@ -272,7 +272,7 @@ sr_gdb_stacktrace_find_crash_thread(struct sr_gdb_stacktrace *stacktrace)
      * thread by that value.
      */
     struct sr_gdb_thread *thread;
-    if (stacktrace->crash_tid != -1)
+    if (stacktrace->crash_tid != UINT32_MAX)
     {
         thread = stacktrace->threads;
         while (thread)

--- a/lib/json.c
+++ b/lib/json.c
@@ -357,7 +357,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                 case ']':
                     if (top && top->type == SR_JSON_ARRAY)
                         flags = (flags & ~ (flag_need_comma | flag_seek_value)) | flag_next;
-                    else if (!top || (!state.settings.settings & SR_JSON_RELAXED_COMMAS))
+                    else if (!top || !(state.settings.settings & SR_JSON_RELAXED_COMMAS))
                     {
                         location->column = e_off;
                         location->message = sr_strdup("Unexpected ]");
@@ -484,7 +484,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                         continue;
 
                     case '"':
-                        if (flags & flag_need_comma && (!state.settings.settings & SR_JSON_RELAXED_COMMAS))
+                        if (flags & flag_need_comma && !(state.settings.settings & SR_JSON_RELAXED_COMMAS))
                         {
                             location->column = e_off;
                             location->message = sr_strdup("Expected , before \"");

--- a/lib/json.c
+++ b/lib/json.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include <assert.h>
 
 typedef unsigned short json_uchar;
@@ -190,10 +191,8 @@ sr_json_parse_ex(struct sr_json_settings *settings,
 
     memset(&state, 0, sizeof(struct json_state));
     memcpy(&state.settings, settings, sizeof(struct sr_json_settings));
-    memset(&state.uint_max, 0xFF, sizeof(state.uint_max));
-    memset(&state.ulong_max, 0xFF, sizeof(state.ulong_max));
-    state.uint_max -= 8; /* limit of how much can be added before next check */
-    state.ulong_max -= 8;
+    state.uint_max = UINT_MAX - 8; /* limit of how much can be added before next check */
+    state.ulong_max = ULONG_MAX - 8;
 
     for (state.first_pass = 1; state.first_pass >= 0; --state.first_pass)
     {

--- a/lib/ruby_frame.c
+++ b/lib/ruby_frame.c
@@ -451,7 +451,7 @@ void
 sr_ruby_frame_append_to_str(struct sr_ruby_frame *frame,
                             struct sr_strbuf *dest)
 {
-    for (int i = 0; i < frame->rescue_level; i++)
+    for (uint32_t i = 0; i < frame->rescue_level; i++)
     {
         sr_strbuf_append_str(dest, "rescue in ");
     }

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -32,7 +32,8 @@
 #include <ctype.h>
 
 #define ANONYMIZED_PATH "/home/anonymized"
-
+/* Maximum allowed size of a file when reading into memory. Currently 20 MB. */
+#define FILE_SIZE_LIMIT 20000000L
 
 /* The prototype is in C++ header cxxabi.h, let's just copypaste it here
  * instead of fiddling with include directories */
@@ -302,10 +303,9 @@ sr_file_to_string(const char *filename,
 
     lseek(fd, 0, SEEK_SET); /* No reason to fail. */
 
-    static const size_t FILE_SIZE_LIMIT = 20000000; /* ~ 20 MB */
     if (size > FILE_SIZE_LIMIT)
     {
-        *error_message = sr_asprintf("Input file too big (%lld). Maximum size is %zu.",
+        *error_message = sr_asprintf("Input file too big (%lld). Maximum size is %ld.",
                                      (long long)size,
                                      FILE_SIZE_LIMIT);
 


### PR DESCRIPTION
* Use `*_MAX` constants instead of `-1` in unsigned comparisons.
* Use fitting types (`size_t`, `unsigned long`, etc.) where appropriate instead of the generic `int`.
* Correct parenthesization for bitfield tests.
* Document when a core stack frame's address may be unknown.