### PR TITLE
Update JSON parser to latest upstream version

### DIFF
--- a/include/json.h
+++ b/include/json.h
@@ -47,10 +47,7 @@ struct sr_strbuf;
 struct sr_json_settings
 {
    unsigned long max_memory;
-   int settings;
 };
-
-#define SR_JSON_RELAXED_COMMAS 1
 
 enum sr_json_type
 {

--- a/lib/json.c
+++ b/lib/json.c
@@ -438,7 +438,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                     else
                     {
                         location->column = e_off;
-                        location->message = sr_strdup("Unexpected ]");
+                        location->message = sr_strdup("Unexpected `]`");
                         goto e_failed;
                     }
 
@@ -455,7 +455,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                         else
                         {
                             location->column = e_off;
-                            location->message = sr_asprintf("Expected , before %c", b);
+                            location->message = sr_asprintf("Expected `,` before `%c`", b);
                             goto e_failed;
                         }
                     }
@@ -469,7 +469,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                         else
                         {
                             location->column = e_off;
-                            location->message = sr_asprintf("Expected : before %c", b);
+                            location->message = sr_asprintf("Expected `:` before `%c`", b);
                             goto e_failed;
                         }
                     }
@@ -585,7 +585,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                         else
                         {
                             location->column = e_off;
-                            location->message = sr_asprintf("Unexpected %c when seeking value", b);
+                            location->message = sr_asprintf("Unexpected `%c` when seeking value", b);
                             goto e_failed;
                         }
                     }
@@ -605,7 +605,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                         if (flags & flag_need_comma)
                         {
                             location->column = e_off;
-                            location->message = sr_strdup("Expected , before \"");
+                            location->message = sr_strdup("Expected `,` before `\"`");
                             goto e_failed;
                         }
 
@@ -985,7 +985,8 @@ json_check_type(struct sr_json_value *value, enum sr_json_type type,
     char *type_str = type_names[type];
 
     if (error_message)
-        *error_message = sr_asprintf("Invalid type of %s; %s expected", name, type_str);
+        *error_message = sr_asprintf("Invalid type of `%s`; `%s` expected",
+                name, type_str);
     return false;
 }
 

--- a/lib/json.c
+++ b/lib/json.c
@@ -582,10 +582,21 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                             flags |= flag_num_negative;
                             continue;
                         }
+                        else if (!b)
+                        {
+                            /* End of file reached, but not expected */
+                            location->column = e_off;
+                            location->message = sr_strdup(top
+                                    ? "Unexpected EOF"
+                                    : "Empty input");
+                            goto e_failed;
+                        }
                         else
                         {
+                            /* Unexpected character in input */
                             location->column = e_off;
-                            location->message = sr_asprintf("Unexpected `%c` when seeking value", b);
+                            location->message = sr_asprintf("Unexpected `%c` when "
+                                    "seeking value", b);
                             goto e_failed;
                         }
                     }

--- a/lib/json.c
+++ b/lib/json.c
@@ -85,12 +85,12 @@ static void *
 json_alloc(struct json_state *state, unsigned long size, int zero)
 {
     if ((state->ulong_max - state->used_memory) < size)
-        return 0;
+        return NULL;
 
     if (state->settings.max_memory
         && (state->used_memory += size) > state->settings.max_memory)
     {
-        return 0;
+        return NULL;
     }
 
     return zero ? calloc(size, 1) : malloc(size);
@@ -227,7 +227,8 @@ sr_json_parse_ex(struct sr_json_settings *settings,
     }
 
     memcpy(&state.settings, settings, sizeof(struct sr_json_settings));
-    state.uint_max = UINT_MAX - 8; /* limit of how much can be added before next check */
+    /* limit of how much can be added before next check */
+    state.uint_max = UINT_MAX - 8;
     state.ulong_max = ULONG_MAX - 8;
 
     for (state.first_pass = 1; state.first_pass >= 0; --state.first_pass)
@@ -237,7 +238,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
         char *string = NULL;
         unsigned string_length = 0;
 
-        top = root = 0;
+        top = root = NULL;
         flags = flag_seek_value;
 
         location->line = 1;
@@ -265,11 +266,11 @@ sr_json_parse_ex(struct sr_json_settings *settings,
 
                     switch (b)
                     {
-                    case 'b':  string_add ('\b');  break;
-                    case 'f':  string_add ('\f');  break;
-                    case 'n':  string_add ('\n');  break;
-                    case 'r':  string_add ('\r');  break;
-                    case 't':  string_add ('\t');  break;
+                    case 'b': string_add('\b'); break;
+                    case 'f': string_add('\f'); break;
+                    case 'n': string_add('\n'); break;
+                    case 'r': string_add('\r'); break;
+                    case 't': string_add('\t'); break;
                     case 'u':
 
                         if (end - state.ptr <= 4 ||
@@ -385,10 +386,10 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                         break;
                     case SR_JSON_OBJECT:
                         if (state.first_pass)
-                            (*(char**) &top->u.object.values) += string_length + 1;
+                            (*(char**)&top->u.object.values) += string_length + 1;
                         else
                         {
-                            top->u.object.values [top->u.object.length].name =
+                            top->u.object.values[top->u.object.length].name =
                                 (char*)top->_reserved.object_mem;
 
                             (*(char**)&top->_reserved.object_mem) += string_length + 1;
@@ -541,7 +542,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                         flags |= flag_next;
                         break;
                     default:
-                        if (isdigit (b) || b == '-')
+                        if (isdigit(b) || b == '-')
                         {
                             if (!new_value(&state, &top, &root, &alloc, SR_JSON_INTEGER))
                                 goto e_alloc_failure;
@@ -804,7 +805,7 @@ sr_json_parse_ex(struct sr_json_settings *settings,
                     };
                 }
 
-                if ( (++ top->parent->u.array.length) > state.uint_max)
+                if ((++top->parent->u.array.length) > state.uint_max)
                     goto e_overflow;
 
                 top = top->parent;
@@ -972,6 +973,7 @@ static char *type_names[] = {
    [SR_JSON_BOOLEAN] = "boolean",
    [SR_JSON_NULL]    = "null",
 };
+
 bool
 json_check_type(struct sr_json_value *value, enum sr_json_type type,
                 const char *name, char **error_message)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,6 +51,7 @@ TESTSUITE_AT =		\
   testsuite.at		\
   utils.at 		\
   strbuf.at		\
+  json.at		\
   gdb_frame.at 		\
   gdb_thread.at 	\
   gdb_stacktrace.at  	\

--- a/tests/json.at
+++ b/tests/json.at
@@ -226,6 +226,7 @@ AT_TESTFUN([sr_json_invalid],
 [[
 #include "json.h"
 #include <assert.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* Note: Square brackets are sometimes written as \x5b and \x5d to circumvent
@@ -238,16 +239,28 @@ main(void)
   char *error_message = NULL;
   struct sr_json_value *value = NULL;
 
-  /* Empty input is not valid */
+  /* Empty input is not allowed */
   value = sr_json_parse("", &error_message);
   assert(value == NULL);
-  assert(error_message != NULL);
+  assert(strcmp(error_message, "Line 1, column 0: Empty input") == 0);
   free(error_message);
 
-  /* Mismatched bracket */
+  /* Mismatched closing bracket */
+  value = sr_json_parse("\x5d", &error_message);
+  assert(value == NULL);
+  assert(strcmp(error_message, "Line 1, column 0: Unexpected `\x5d`") == 0);
+  free(error_message);
+
+  /* Mismatched opening bracket */
   value = sr_json_parse("\x5b", &error_message);
   assert(value == NULL);
-  assert(error_message != NULL);
+  assert(strcmp(error_message, "Line 1, column 1: Unexpected EOF") == 0);
+  free(error_message);
+
+  /* Mismatched quote */
+  value = sr_json_parse("\x5b true, null, \"unfinished string  ", &error_message);
+  assert(value == NULL);
+  assert(strcmp(error_message, "Line 1, column 34: Unexpected EOF in string") == 0);
   free(error_message);
 
   /* Mismatched bracket reprise */

--- a/tests/json.at
+++ b/tests/json.at
@@ -1,0 +1,288 @@
+# Checking the satyr. -*- Autotest -*-
+
+AT_BANNER([JSON parser])
+
+## ---------------------- ##
+## sr_json_valid_toplevel ##
+## ---------------------- ##
+
+AT_TESTFUN([sr_json_valid_toplevel],
+[[
+#include "json.h"
+#include <assert.h>
+#include <string.h>
+
+int
+main(void)
+{
+  char *error_message = NULL;
+  struct sr_json_value *value = NULL;
+
+  /* The null value */
+  value = sr_json_parse("\nnull\n\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_NULL);
+  sr_json_value_free(value);
+
+  /* Boolean true */
+  value = sr_json_parse("\ntrue\n\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_BOOLEAN);
+  assert(value->u.boolean == 1);
+  sr_json_value_free(value);
+
+  /* Boolean false */
+  value = sr_json_parse("\n\t\tfalse", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_BOOLEAN);
+  assert(value->u.boolean == 0);
+  sr_json_value_free(value);
+
+  /* Empty string */
+  value = sr_json_parse("\n\"\"\n\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_STRING);
+  assert(value->u.string.length == 0);
+  sr_json_value_free(value);
+
+  /* Integer zero */
+  value = sr_json_parse("\n0\n\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_INTEGER);
+  sr_json_value_free(value);
+
+  /* Floating-point zero */
+  value = sr_json_parse("\n0.0\n\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_DOUBLE);
+  sr_json_value_free(value);
+
+  /* Empty array */
+  value = sr_json_parse("[\n\n]\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_ARRAY);
+  assert(value->u.array.length == 0);
+  sr_json_value_free(value);
+
+  /* Empty object */
+  value = sr_json_parse("\n{  }\n\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_OBJECT);
+  assert(value->u.object.length == 0);
+  sr_json_value_free(value);
+
+  return 0;
+}
+]])
+
+## -------------------- ##
+## sr_json_valid_object ##
+## -------------------- ##
+
+AT_TESTFUN([sr_json_valid_object],
+[[
+#include "json.h"
+#include <assert.h>
+#include <string.h>
+
+int
+main(void)
+{
+  char *error_message = NULL;
+  struct sr_json_value *value = NULL, *child = NULL;
+
+  /* Object with some doubles */
+  value = sr_json_parse("{ \"min\": -1.0e+28, \"max\": 1.0e+28 }\n\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_OBJECT);
+  assert(value->u.object.length == 2);
+
+  assert(value->u.object.values[0].name != NULL);
+  assert(strcmp(value->u.object.values[0].name, "min") == 0);
+  child = value->u.object.values[0].value;
+  assert(child != NULL);
+  assert(child->type == SR_JSON_DOUBLE);
+  assert(child->u.dbl == -1.0e+28);
+
+  assert(value->u.object.values[1].name != NULL);
+  assert(strcmp(value->u.object.values[1].name, "max") == 0);
+  child = value->u.object.values[1].value;
+  assert(child != NULL);
+  assert(child->type == SR_JSON_DOUBLE);
+  assert(child->u.dbl == 1.0e+28);
+
+  sr_json_value_free(value);
+
+  return 0;
+}
+]])
+
+## ------------------- ##
+## sr_json_valid_array ##
+## ------------------- ##
+
+AT_TESTFUN([sr_json_valid_array],
+[[
+#include "json.h"
+#include <assert.h>
+#include <string.h>
+
+int
+main(void)
+{
+  char *error_message = NULL;
+  struct sr_json_value *value = NULL;
+
+  /* Array with a bunch of integers */
+  value = sr_json_parse("[ 44, 55223,\n  8931, -432,\n 311 ]\n", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_ARRAY);
+  assert(value->u.array.length == 5);
+
+  assert(value->u.array.values[0]->type == SR_JSON_INTEGER);
+  assert(value->u.array.values[0]->u.integer == 44);
+
+  assert(value->u.array.values[1]->type == SR_JSON_INTEGER);
+  assert(value->u.array.values[1]->u.integer == 55223);
+
+  assert(value->u.array.values[2]->type == SR_JSON_INTEGER);
+  assert(value->u.array.values[2]->u.integer == 8931);
+
+  assert(value->u.array.values[3]->type == SR_JSON_INTEGER);
+  assert(value->u.array.values[3]->u.integer == -432);
+
+  assert(value->u.array.values[4]->type == SR_JSON_INTEGER);
+  assert(value->u.array.values[4]->u.integer == 311);
+
+  sr_json_value_free(value);
+
+  /* Array with two Booleans and a UTF-8-encoded string */
+  value = sr_json_parse("[ true, false, \"\\u20AC\\u20AD\" ]", &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_ARRAY);
+  assert(value->u.array.length == 3);
+
+  assert(value->u.array.values[0]->type == SR_JSON_BOOLEAN);
+  assert(value->u.array.values[0]->u.boolean == 1);
+
+  assert(value->u.array.values[1]->type == SR_JSON_BOOLEAN);
+  assert(value->u.array.values[1]->u.boolean == 0);
+
+  assert(value->u.array.values[2]->type == SR_JSON_STRING);
+  assert(value->u.array.values[2]->u.string.length == 6);
+  assert(strcmp(value->u.array.values[2]->u.string.ptr,
+    "\xe2\x82\xac\xe2\x82\xad") == 0);
+
+  sr_json_value_free(value);
+
+  /* Array with a bunch of doubles */
+  value = sr_json_parse("[0.4e004, 0.8e-006, 0.4e+009, 4e006, 2e-006,  1e+0011 ]\n",
+    &error_message);
+  assert(value != NULL);
+  assert(error_message == NULL);
+  assert(value->type == SR_JSON_ARRAY);
+  assert(value->u.array.length == 6);
+
+  assert(value->u.array.values[0]->type == SR_JSON_DOUBLE);
+  assert(value->u.array.values[0]->u.dbl == 4e3);
+
+  assert(value->u.array.values[1]->type == SR_JSON_DOUBLE);
+  assert(value->u.array.values[1]->u.dbl == 8e-7);
+
+  assert(value->u.array.values[2]->type == SR_JSON_DOUBLE);
+  assert(value->u.array.values[2]->u.dbl == 4e8);
+
+  assert(value->u.array.values[3]->type == SR_JSON_DOUBLE);
+  assert(value->u.array.values[3]->u.dbl == 4e6);
+
+  assert(value->u.array.values[4]->type == SR_JSON_DOUBLE);
+  assert(value->u.array.values[4]->u.dbl == 2e-6);
+
+  assert(value->u.array.values[5]->type == SR_JSON_DOUBLE);
+  assert(value->u.array.values[5]->u.dbl == 1e11);
+
+  sr_json_value_free(value);
+
+  return 0;
+}
+]])
+
+## --------------- ##
+## sr_json_invalid ##
+## --------------- ##
+
+AT_TESTFUN([sr_json_invalid],
+[[
+#include "json.h"
+#include <assert.h>
+#include <string.h>
+
+/* Note: Square brackets are sometimes written as \x5b and \x5d to circumvent
+ * M4's quoting rules and so that the program is a valid input for the preprocessor
+ */
+
+int
+main(void)
+{
+  char *error_message = NULL;
+  struct sr_json_value *value = NULL;
+
+  /* Empty input is not valid */
+  value = sr_json_parse("", &error_message);
+  assert(value == NULL);
+  assert(error_message != NULL);
+  free(error_message);
+
+  /* Mismatched bracket */
+  value = sr_json_parse("\x5b", &error_message);
+  assert(value == NULL);
+  assert(error_message != NULL);
+  free(error_message);
+
+  /* Mismatched bracket reprise */
+  value = sr_json_parse("[ 92219, true ]\x5b", &error_message);
+  assert(value == NULL);
+  assert(strcmp(error_message, "Line 1, column 15: Trailing garbage: `\x5b`") == 0);
+  free(error_message);
+
+  /* Mismatched bracket for objects */
+  value = sr_json_parse(" {}\n} ", &error_message);
+  assert(value == NULL);
+  assert(strcmp(error_message, "Line 2, column 1: Trailing garbage: `}`") == 0);
+  free(error_message);
+
+  /* Garbage in between */
+  value = sr_json_parse("{\"hello\": \"world\", \"value\": null, true, \"key\": 15}",
+    &error_message);
+  assert(value == NULL);
+  assert(strcmp(error_message, "Line 1, column 34: Unexpected `t` in object") == 0);
+  free(error_message);
+
+  /* Leading zeros are not allowed */
+  value = sr_json_parse("[ 0311 ]",
+    &error_message);
+  assert(value == NULL);
+  assert(strcmp(error_message, "Line 1, column 3: Unexpected `0` before `3`") == 0);
+  free(error_message);
+
+  /* Incomplete input */
+  value = sr_json_parse("\x5b\nnull,\nfal",
+    &error_message);
+  assert(value == NULL);
+  assert(strcmp(error_message, "Line 3, column 1: Unknown value") == 0);
+  free(error_message);
+
+  return 0;
+}
+]])

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -3,6 +3,7 @@
 
 m4_include([utils.at])
 m4_include([strbuf.at])
+m4_include([json.at])
 m4_include([gdb_frame.at])
 m4_include([gdb_thread.at])
 m4_include([gdb_stacktrace.at])


### PR DESCRIPTION
This set of changes updates the JSON parser to the latest available version of [upstream](https://github.com/udp/json-parser/), dating to February 2018.

I migrated the upstream changes and interleaved them with modification done in satyr, paying special attention to code style and naming. I did not migrate support for parsing comments as it doesn't seem to be useful for satyr.

I also added a few unit tests for simple cases of valid and invalid inputs.