### PR TITLE
Fix -Wreturn-type warning

### DIFF
--- a/tests/ruby_frame.at
+++ b/tests/ruby_frame.at
@@ -214,7 +214,7 @@ check(char *input)
 
   json_object_put(root);
 
-  return 0;
+  return;
 }
 
 int

--- a/tests/ruby_frame.at
+++ b/tests/ruby_frame.at
@@ -213,8 +213,6 @@ check(char *input)
   assert(0 == sr_ruby_frame_cmp(frame1, frame2));
 
   json_object_put(root);
-
-  return;
 }
 
 int


### PR DESCRIPTION
ruby_frame.at:216:3: error: void function 'check' should not return a value [-Wreturn-type]

clang treates these as errors by default, so this was breaking the build with clang.