### PR TITLE
python: Adapt to changes made in PEP 590

### DIFF
--- a/python/py_base_frame.c
+++ b/python/py_base_frame.c
@@ -49,7 +49,7 @@ sr_py_base_frame_type =
     sizeof(struct sr_py_base_frame),        /* tp_basicsize */
     0,                          /* tp_itemsize */
     NULL,                       /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_base_stacktrace.c
+++ b/python/py_base_stacktrace.c
@@ -66,7 +66,7 @@ PyTypeObject sr_py_single_stacktrace_type = {
     sizeof(struct sr_py_base_thread), /* tp_basicsize */
     0,                              /* tp_itemsize */
     NULL,                           /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */
@@ -137,7 +137,7 @@ PyTypeObject sr_py_multi_stacktrace_type = {
     sizeof(struct sr_py_multi_stacktrace), /* tp_basicsize */
     0,                              /* tp_itemsize */
     NULL,                           /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */

--- a/python/py_base_thread.c
+++ b/python/py_base_thread.c
@@ -69,7 +69,7 @@ sr_py_base_thread_type =
     sizeof(struct sr_py_base_thread), /* tp_basicsize */
     0,                          /* tp_itemsize */
     NULL,                       /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_cluster.c
+++ b/python/py_cluster.c
@@ -40,7 +40,7 @@ sr_py_dendrogram_type =
     sizeof(struct sr_py_dendrogram),   /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_dendrogram_free,      /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_core_frame.c
+++ b/python/py_core_frame.c
@@ -78,7 +78,7 @@ sr_py_core_frame_type =
     sizeof(struct sr_py_core_frame), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_core_frame_free,      /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_core_stacktrace.c
+++ b/python/py_core_stacktrace.c
@@ -70,7 +70,7 @@ PyTypeObject sr_py_core_stacktrace_type = {
     sizeof(struct sr_py_core_stacktrace), /* tp_basicsize */
     0,                              /* tp_itemsize */
     sr_py_core_stacktrace_free,     /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */

--- a/python/py_core_thread.c
+++ b/python/py_core_thread.c
@@ -49,7 +49,7 @@ PyTypeObject sr_py_core_thread_type =
     sizeof(struct sr_py_core_thread), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_core_thread_free,     /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_gdb_frame.c
+++ b/python/py_gdb_frame.c
@@ -131,7 +131,7 @@ sr_py_gdb_frame_type =
     sizeof(struct sr_py_gdb_frame),        /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_gdb_frame_free,       /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_gdb_sharedlib.c
+++ b/python/py_gdb_sharedlib.c
@@ -38,7 +38,7 @@ sr_py_gdb_sharedlib_type =
     sizeof(struct sr_py_gdb_sharedlib),    /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_gdb_sharedlib_free,   /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_gdb_stacktrace.c
+++ b/python/py_gdb_stacktrace.c
@@ -96,7 +96,7 @@ PyTypeObject sr_py_gdb_stacktrace_type = {
     sizeof(struct sr_py_gdb_stacktrace),        /* tp_basicsize */
     0,                              /* tp_itemsize */
     sr_py_gdb_stacktrace_free,       /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */

--- a/python/py_gdb_thread.c
+++ b/python/py_gdb_thread.c
@@ -64,7 +64,7 @@ PyTypeObject sr_py_gdb_thread_type =
     sizeof(struct sr_py_gdb_thread),       /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_gdb_thread_free,      /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_java_frame.c
+++ b/python/py_java_frame.c
@@ -80,7 +80,7 @@ sr_py_java_frame_type =
     sizeof(struct sr_py_java_frame),   /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_java_frame_free,     /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_java_stacktrace.c
+++ b/python/py_java_stacktrace.c
@@ -33,7 +33,7 @@ PyTypeObject sr_py_java_stacktrace_type = {
     sizeof(struct sr_py_java_stacktrace),        /* tp_basicsize */
     0,                              /* tp_itemsize */
     sr_py_java_stacktrace_free,    /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */

--- a/python/py_java_thread.c
+++ b/python/py_java_thread.c
@@ -64,7 +64,7 @@ PyTypeObject sr_py_java_thread_type =
     sizeof(struct sr_py_java_thread),   /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_java_thread_free,     /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_js_frame.c
+++ b/python/py_js_frame.c
@@ -73,7 +73,7 @@ sr_py_js_frame_type =
     sizeof(struct sr_py_js_frame), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_js_frame_free,        /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_js_stacktrace.c
+++ b/python/py_js_stacktrace.c
@@ -69,7 +69,7 @@ PyTypeObject sr_py_js_stacktrace_type = {
     sizeof(struct sr_py_js_stacktrace), /* tp_basicsize */
     0,                              /* tp_itemsize */
     sr_py_js_stacktrace_free,       /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */

--- a/python/py_koops_frame.c
+++ b/python/py_koops_frame.c
@@ -92,7 +92,7 @@ sr_py_koops_frame_type =
     sizeof(struct sr_py_koops_frame),        /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_koops_frame_free,     /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_koops_stacktrace.c
+++ b/python/py_koops_stacktrace.c
@@ -62,7 +62,7 @@ PyTypeObject sr_py_koops_stacktrace_type = {
     sizeof(struct sr_py_koops_stacktrace),        /* tp_basicsize */
     0,                              /* tp_itemsize */
     sr_py_koops_stacktrace_free,    /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */

--- a/python/py_metrics.c
+++ b/python/py_metrics.c
@@ -78,7 +78,7 @@ sr_py_distances_type =
     sizeof(struct sr_py_distances),    /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_distances_free,       /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */
@@ -128,7 +128,7 @@ sr_py_distances_part_type =
     sizeof(struct sr_py_distances_part), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_distances_part_free,  /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_operating_system.c
+++ b/python/py_operating_system.c
@@ -61,7 +61,7 @@ sr_py_operating_system_type =
     sizeof(struct sr_py_operating_system), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_operating_system_free,/* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_python_frame.c
+++ b/python/py_python_frame.c
@@ -77,7 +77,7 @@ sr_py_python_frame_type =
     sizeof(struct sr_py_python_frame),        /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_python_frame_free,    /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_python_stacktrace.c
+++ b/python/py_python_stacktrace.c
@@ -54,7 +54,7 @@ PyTypeObject sr_py_python_stacktrace_type = {
     sizeof(struct sr_py_python_stacktrace), /* tp_basicsize */
     0,                              /* tp_itemsize */
     sr_py_python_stacktrace_free,   /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */

--- a/python/py_report.c
+++ b/python/py_report.c
@@ -100,7 +100,7 @@ sr_py_report_type =
     sizeof(struct sr_py_report), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_report_free,          /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_rpm_package.c
+++ b/python/py_rpm_package.c
@@ -67,7 +67,7 @@ sr_py_rpm_package_type =
     sizeof(struct sr_py_rpm_package), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_rpm_package_free,     /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_ruby_frame.c
+++ b/python/py_ruby_frame.c
@@ -77,7 +77,7 @@ sr_py_ruby_frame_type =
     sizeof(struct sr_py_ruby_frame), /* tp_basicsize */
     0,                          /* tp_itemsize */
     sr_py_ruby_frame_free,      /* tp_dealloc */
-    NULL,                       /* tp_print */
+    0,                          /* tp_vectorcall_offset */
     NULL,                       /* tp_getattr */
     NULL,                       /* tp_setattr */
     NULL,                       /* tp_compare */

--- a/python/py_ruby_stacktrace.c
+++ b/python/py_ruby_stacktrace.c
@@ -49,7 +49,7 @@ PyTypeObject sr_py_ruby_stacktrace_type = {
     sizeof(struct sr_py_ruby_stacktrace), /* tp_basicsize */
     0,                              /* tp_itemsize */
     sr_py_ruby_stacktrace_free,     /* tp_dealloc */
-    NULL,                           /* tp_print */
+    0,                              /* tp_vectorcall_offset */
     NULL,                           /* tp_getattr */
     NULL,                           /* tp_setattr */
     NULL,                           /* tp_compare */


### PR DESCRIPTION
The unused tp_print field in PyTypeObject has been replaced with
tp_vectorcall_offset and has a different type.

https://www.python.org/dev/peps/pep-0590/