### PR TITLE
Add GitHub Actions workflow for building PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,44 @@
+name: Build
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+jobs:
+  build:
+    name: Build
+    container: 
+      image: fedora:latest
+      # All for gcore in core_stacktrace tests.
+      options: "--cap-add=SYS_PTRACE --security-opt=apparmor:unconfined --security-opt=seccomp=unconfined"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v2
+
+      - name: Install build environment
+        run: |
+          dnf --assumeyes install dnf-plugins-core
+          dnf --assumeyes copr enable @abrt/devel
+          dnf --assumeyes install \
+            @c-development @development-tools @rpm-development-tools \
+            intltool
+
+      - name: Install build dependencies
+        run: ./autogen.sh sysdeps --install
+
+      - name: Configure build
+        run: ./autogen.sh
+
+      - name: Build
+        run: make --load-average=2
+
+      - name: Run tests
+        run: make check
+
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        with:
+          name: testsuite.log
+          path: tests/testsuite.log
+        if: ${{ failure() }}

--- a/satyr.spec.in
+++ b/satyr.spec.in
@@ -34,13 +34,13 @@ BuildRequires: automake
 BuildRequires: gcc-c++
 BuildRequires: gdb
 BuildRequires: gperf
-BuildRequires: nettle-devel
-BuildRequires: pkgconfig(json-c)
+BuildRequires: nettle-devel%{?_isa}
+BuildRequires: json-c-devel%{?_isa}
 %if %{with python3}
 BuildRequires: python3-sphinx
 %endif # with python3
-Requires: json-c
-Requires: nettle
+Requires: json-c%{?_isa}
+Requires: nettle%{?_isa}
 
 %description
 Satyr is a library that can be used to create and process microreports.


### PR DESCRIPTION
This commit adds a GitHub Actions workflow to replace the Jenkins jobs
on the internal Red Hat instance. Though this does not use Mock, it
shouldn’t matter for our purposes.