### PR TITLE
spec, RELEASE: README -> README.md

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,8 @@ satyr_LDADD = lib/libsatyr.la
 man_MANS = satyr.1
 EXTRA_DIST = satyr.1.in
 
+dist_doc_DATA = README.md
+
 satyr.1: satyr.1.in
 	sed -e "s,\@PACKAGE_STRING\@,$(PACKAGE_STRING),g" $< > $@
 

--- a/RELEASE
+++ b/RELEASE
@@ -18,7 +18,7 @@ YYYY-MM-DD).
 * NEWS: Document recent changes.
 
 
-4. Read and update the README file, if you see that some change made
+4. Read and update the README.md file, if you see that some change made
 since the last release expanded the project scope, or added
 significant new functionality.
 

--- a/satyr.spec.in
+++ b/satyr.spec.in
@@ -107,7 +107,7 @@ make check|| {
 %endif
 
 %files
-%doc README NEWS
+%doc README.md NEWS
 %license COPYING
 %{_bindir}/satyr
 %{_mandir}/man1/%{name}.1*


### PR DESCRIPTION
Fallout from previous commit

However, `make rpm` still finishes with
"File not found: /home/mfabik/rpmbuild/BUILDROOT/satyr-0.31.15.gda1d87-1.fc32.x86_64/usr/share/doc/satyr/README.md"  
  
@msuchy, any ideas what can be causing this? I'm quite at a loss.

Signed-off-by: Michal Fabik <mfabik@redhat.com>