### PR TITLE
spec: Output logs from failed tests

### DIFF
--- a/satyr.spec.in
+++ b/satyr.spec.in
@@ -95,6 +95,7 @@ find %{buildroot} -name "*.la" -delete
 make check|| {
     # find and print the logs of failed test
     # do not cat tests/testsuite.log because it contains a lot of bloat
+    cat tests/test-suite.log
     find tests/testsuite.dir -name "testsuite.log" -print -exec cat '{}' \;
     exit 1
 }


### PR DESCRIPTION
After the changes started in c465ace, spec-driven builds no longer
output the logs for failed tests as the logs are now stored in .log
files named after the corresponding test C source (and binary), rather
than in tests/testsuite.dir. This, however, doesn't apply to Python
bindings tests, which is why the `find` on tests/testsuite.dir is
retained.

Signed-off-by: Michal Fabik <mfabik@redhat.com>