### PR TITLE
tests: Use correct format specifier for size_t

### DIFF
--- a/tests/utils.c
+++ b/tests/utils.c
@@ -277,7 +277,7 @@ test_indent(void)
 
 void do_check(char **in, size_t inlen, char **out, size_t outlen)
 {
-    printf("%ld %ld\n", inlen, outlen);
+    printf("%zd %zd\n", inlen, outlen);
     sr_struniq(in, &inlen);
     g_assert_true(inlen == outlen);
     


### PR DESCRIPTION
Using `%ld` with a var of type `size_t` causes a warning on platforms where
`size_t` isn't the same as `long int`.

Signed-off-by: Michal Fabik <mfabik@redhat.com>