### PR TITLE
spec: Use autoreconf in %build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,9 @@ satyr_SOURCES = satyr.c
 satyr_LDADD = lib/libsatyr.la
 
 man_MANS = satyr.1
-EXTRA_DIST = satyr.1.in
+EXTRA_DIST = \
+    satyr.1.in \
+    satyr-version
 
 dist_doc_DATA = README.md
 

--- a/satyr.spec.in
+++ b/satyr.spec.in
@@ -77,6 +77,8 @@ Python 3 bindings for %{name}.
 %setup -q
 
 %build
+autoreconf
+
 %configure \
 %if %{without python3}
         --without-python3 \


### PR DESCRIPTION
This way, when stuff is fixed in automake, the source tarball does not
need to be re-generated in upstream to use the fix.

Resolves rhbz#1898063

Patch contributed by Miro Hrončok <miro@hroncok.cz>
Lifted from e17dd1d8 in libreport
Signed-off-by: Michal Fabik <mfabik@redhat.com>