### PR TITLE
sr_distances_cluster_objects: Check arg safety

### DIFF
--- a/lib/cluster.c
+++ b/lib/cluster.c
@@ -107,10 +107,13 @@ cluster_reverse(struct cluster *cluster)
 struct sr_dendrogram *
 sr_distances_cluster_objects(struct sr_distances *distances)
 {
+    assert(distances->n);
     int i, j, merges, m = distances->m, n = distances->n;
 
     struct sr_distances *cluster_distances;
     struct cluster clusters[n];
+    /* to stop gcc 11 from complaining about uninitialized variables */
+    clusters[0].objects = NULL;
 
     float merge_levels[n];
 


### PR DESCRIPTION
Add an `assert()` to prevent calling `cluster_clean()` on a non-existent
struct. (And ISO C forbids zero-length arrays anyway.)

Also, initialize `clusters[0].objects` right after declaration.
GCC 11 complains about uninitialized variables when the initialization
happens in a lower scope (inside a loop in this case) than the call to
`free`, even when entering the lower scope is guaranteed.

Signed-off-by: Michal Fabik <mfabik@redhat.com>