### PR TITLE
Use g_free for g_malloc'd memory

### DIFF
--- a/include/gdb/frame.h
+++ b/include/gdb/frame.h
@@ -339,7 +339,7 @@ sr_gdb_frame_parse_function_name_template_args(const char **input,
  * A pointer pointing to an uninitialized pointer. This function
  * allocates a string and sets the pointer to it if it parses the
  * function name from the input successfully.  The memory returned
- * this way must be released by the caller using the function free().
+ * this way must be released by the caller using the function g_free().
  * If this function returns true, this pointer is guaranteed to be
  * non-NULL.
  * @param location

--- a/include/gdb/stacktrace.h
+++ b/include/gdb/stacktrace.h
@@ -196,7 +196,7 @@ sr_gdb_stacktrace_quality_complex(struct sr_gdb_stacktrace *stacktrace);
  * function.
  * @returns
  * This function never returns NULL. The caller is responsible for
- * releasing the returned memory using function free().
+ * releasing the returned memory using function g_free().
  */
 char *
 sr_gdb_stacktrace_to_text(struct sr_gdb_stacktrace *stacktrace,
@@ -317,7 +317,7 @@ sr_gdb_stacktrace_set_libnames(struct sr_gdb_stacktrace *stacktrace);
  * @returns
  * Brief text representation of the crash thread suitable for being part of a
  * bugzilla comment. The string is allocated by the function and must be freed
- * using the free() function.
+ * using the g_free() function.
  */
 char *
 sr_gdb_stacktrace_to_short_text(struct sr_gdb_stacktrace *stacktrace,

--- a/include/gdb/thread.h
+++ b/include/gdb/thread.h
@@ -251,7 +251,7 @@ sr_gdb_thread_parse_funs(const char *input);
  * comparison.
  * @returns
  * Newly allocated string, which should be released by
- * calling free(). The string can be parsed by sr_gdb_thread_parse_funs().
+ * calling g_free(). The string can be parsed by sr_gdb_thread_parse_funs().
  */
 char *
 sr_gdb_thread_format_funs(struct sr_gdb_thread *thread);

--- a/include/java/thread.h
+++ b/include/java/thread.h
@@ -217,7 +217,7 @@ sr_java_thread_parse(const char **input,
  * comparison.
  * @returns
  * Newly allocated string, which should be released by
- * calling free().
+ * calling g_free().
  */
 char *
 sr_java_thread_format_funs(struct sr_java_thread *thread);

--- a/include/location.h
+++ b/include/location.h
@@ -88,7 +88,7 @@ sr_location_cmp(struct sr_location *location1,
 
 /**
  * Creates a string representation of location.
- * User must delete the returned string using free().
+ * User must delete the returned string using g_free().
  */
 char *
 sr_location_to_string(struct sr_location *location);

--- a/include/report_type.h
+++ b/include/report_type.h
@@ -44,7 +44,7 @@ enum sr_report_type
     SR_REPORT_NUM
 };
 
-/* returns malloc()ed string representation of report_type */
+/* returns g_malloc()ed string representation of report_type */
 char *
 sr_report_type_to_string(enum sr_report_type report_type);
 

--- a/include/stacktrace.h
+++ b/include/stacktrace.h
@@ -124,7 +124,7 @@ sr_stacktrace_get_reason(struct sr_stacktrace *stacktrace);
  * Returns hash of a backtrace. This is a hash in the usual sense that the same
  * stacktraces always have the same hash while two distinct stacktraces have
  * negligible probability of having the same hash. The string is allocated by
- * malloc().
+ * g_malloc().
  */
 char *
 sr_stacktrace_get_bthash(struct sr_stacktrace *stacktrace, enum sr_bthash_flags flags);

--- a/include/stacktrace.h
+++ b/include/stacktrace.h
@@ -73,7 +73,7 @@ sr_stacktrace_parse(enum sr_report_type type, const char *input, char **error_me
 
 /**
  * Returns short textual representation of given stacktrace. At most max_frames
- * are printed. Caller needs to free the result using free() afterwards.
+ * are printed. Caller needs to free the result using g_free() afterwards.
  */
 char *
 sr_stacktrace_to_short_text(struct sr_stacktrace *stacktrace, int max_frames);

--- a/include/thread.h
+++ b/include/thread.h
@@ -156,7 +156,7 @@ sr_thread_normalize(struct sr_thread *thread);
 
 /**
  * Returns the duplication hash. Two threads resulting from the same crash
- * should have the same duphash. The returned string is allocated by malloc().
+ * should have the same duphash. The returned string is allocated by g_malloc().
  *
  * @param thread The thread to hash.
  * @param frames Number of frames to include in the hash. If the value is 0,

--- a/lib/abrt.c
+++ b/lib/abrt.c
@@ -47,7 +47,7 @@ file_contents(const char *directory, const char *file, char **error_message)
     char *path = sr_build_path(directory, file, NULL);
     char *contents = sr_file_to_string(path, error_message);
 
-    free(path);
+    g_free(path);
     return contents;
 }
 
@@ -64,7 +64,7 @@ sr_abrt_print_report_from_dir(const char *directory,
     char *json = sr_report_to_json(report);
     sr_report_free(report);
     puts(json);
-    free(json);
+    g_free(json);
     return true;
 }
 
@@ -108,8 +108,8 @@ create_core_stacktrace(const char *directory, const char *gdb_output,
         core_stacktrace = sr_parse_coredump(coredump_filename,
                 executable_contents, error_message);
 
-    free(executable_contents);
-    free(coredump_filename);
+    g_free(executable_contents);
+    g_free(coredump_filename);
     if (!core_stacktrace)
         return false;
 
@@ -127,8 +127,8 @@ create_core_stacktrace(const char *directory, const char *gdb_output,
                                     json,
                                     error_message);
 
-    free(core_backtrace_filename);
-    free(json);
+    g_free(core_backtrace_filename);
+    g_free(json);
     sr_core_stacktrace_free(core_stacktrace);
     return success;
 }
@@ -235,7 +235,7 @@ sr_abrt_parse_dso_list(const char *text)
                                                   &dso_package->release,
                                                   &dso_package->architecture);
 
-        free(nevra);
+        g_free(nevra);
 
         // If parsing failed, move to the next line.
         if (!success)
@@ -259,7 +259,7 @@ sr_abrt_parse_dso_list(const char *text)
         {
             pos = eol;
             sr_rpm_package_free(dso_package, true);
-            free(line);
+            g_free(line);
             continue;
         }
 
@@ -268,7 +268,7 @@ sr_abrt_parse_dso_list(const char *text)
         // Parse the package install time.
         int len = sr_parse_uint64((const char**)&pos,
                                   &dso_package->install_time);
-        free(line);
+        g_free(line);
 
         if (len <= 0)
         {
@@ -309,7 +309,7 @@ rpm_pkg_from_dir(struct sr_rpm_package *packages,
         *error_message = g_strdup_printf("Epoch '%s' is not a number", epoch_str);
         return NULL;
     }
-    free(epoch_str);
+    g_free(epoch_str);
 
 
     packages->epoch = (uint32_t)epoch;
@@ -355,7 +355,7 @@ rpm_dso_list_from_dir(struct sr_rpm_package *packages,
             packages = sr_rpm_package_uniq(packages);
         }
 
-        free(dso_list_contents);
+        g_free(dso_list_contents);
     }
 
     return packages;
@@ -378,7 +378,7 @@ rpm_interpreter_from_dir(struct sr_rpm_package *packages,
                                                   &interpreter_package->release,
                                                   &interpreter_package->architecture);
 
-        free(interpreter_str);
+        g_free(interpreter_str);
         if (success)
             packages = sr_rpm_package_append(packages, interpreter_package);
         else
@@ -397,7 +397,7 @@ file_exist(const char *directory, const char *filename)
     if (access(path, F_OK) == 0)
         retval = true;
 
-    free(path);
+    g_free(path);
     return retval;
 }
 
@@ -446,7 +446,7 @@ desktop_from_dir(const char *directory,
     char *desktop = strstr(environ_contents, "DESKTOP_SESSION=");
     if (!desktop)
     {
-        free(environ_contents);
+        g_free(environ_contents);
         return NULL;
     }
 
@@ -454,7 +454,7 @@ desktop_from_dir(const char *directory,
        the very first variable or preceeded by a newline */
     if (desktop != environ_contents && *(desktop - 1) != '\n')
     {
-        free(environ_contents);
+        g_free(environ_contents);
         return NULL;
     }
 
@@ -463,7 +463,7 @@ desktop_from_dir(const char *directory,
     *newline = '\0';
 
     char *result = g_strdup(desktop);
-    free(environ_contents);
+    g_free(environ_contents);
 
     return result;
 }
@@ -511,7 +511,7 @@ occurrences_from_dir(const char *directory,
     result = true;
 
 finito:
-    free(count_contents);
+    g_free(count_contents);
     return result;
 }
 
@@ -536,7 +536,7 @@ get_component(const char *directory,
 
             char *artificial_component = g_strdup_printf("%s-unpackaged", basename);
 
-            free(executable);
+            g_free(executable);
             return artificial_component;
         }
     }
@@ -555,7 +555,7 @@ sr_abrt_operating_system_from_dir(const char *directory,
     if (osinfo_contents)
     {
         success = sr_operating_system_parse_etc_os_release(osinfo_contents, os);
-        free(osinfo_contents);
+        g_free(osinfo_contents);
     }
 
     /* fall back to os_release if parsing os_info fails */
@@ -568,7 +568,7 @@ sr_abrt_operating_system_from_dir(const char *directory,
             success = sr_operating_system_parse_etc_system_release(release_contents,
                                                                    &os->name,
                                                                    &os->version);
-            free(release_contents);
+            g_free(release_contents);
         }
     }
 
@@ -607,7 +607,7 @@ sr_abrt_report_from_dir(const char *directory,
     }
 
     report->report_type = sr_abrt_type_from_type(type_contents);
-    free(type_contents);
+    g_free(type_contents);
 
     /* Operating system. */
     report->operating_system = sr_abrt_operating_system_from_dir(
@@ -650,7 +650,7 @@ sr_abrt_report_from_dir(const char *directory,
         report->stacktrace = (struct sr_stacktrace *)sr_core_stacktrace_from_json_text(
                 core_backtrace_contents, error_message);
 
-        free(core_backtrace_contents);
+        g_free(core_backtrace_contents);
         if (!report->stacktrace)
         {
             sr_report_free(report);
@@ -677,7 +677,7 @@ sr_abrt_report_from_dir(const char *directory,
             &contents_pointer,
             &location);
 
-        free(backtrace_contents);
+        g_free(backtrace_contents);
         if (!report->stacktrace)
         {
             *error_message = sr_location_to_string(&location);
@@ -717,7 +717,7 @@ sr_abrt_report_from_dir(const char *directory,
         stacktrace->version = kernel_contents;
         report->stacktrace = (struct sr_stacktrace *)stacktrace;
 
-        free(backtrace_contents);
+        g_free(backtrace_contents);
         if (!report->stacktrace)
         {
             *error_message = sr_location_to_string(&location);
@@ -744,7 +744,7 @@ sr_abrt_report_from_dir(const char *directory,
             &contents_pointer,
             &location);
 
-        free(backtrace_contents);
+        g_free(backtrace_contents);
         if (!report->stacktrace)
         {
             *error_message = sr_location_to_string(&location);
@@ -772,7 +772,7 @@ sr_abrt_report_from_dir(const char *directory,
             &contents_pointer,
             &location);
 
-        free(backtrace_contents);
+        g_free(backtrace_contents);
         if (!report->stacktrace)
         {
             *error_message = sr_location_to_string(&location);
@@ -805,7 +805,7 @@ sr_abrt_report_from_dir(const char *directory,
         sr_js_platform_t platform = sr_js_platform_from_string(analyzer_contents,
                                                                NULL,
                                                                error_message);
-        free(analyzer_contents);
+        g_free(analyzer_contents);
 
         struct sr_location location;
         sr_location_init(&location);
@@ -824,7 +824,7 @@ sr_abrt_report_from_dir(const char *directory,
             /* This message should help maintainers when a new platform
              * appears. */
             warn("Have to try to guess JavaScript platform: %s", *error_message);
-            free(*error_message);
+            g_free(*error_message);
             *error_message = NULL;
 
             report->stacktrace = (struct sr_stacktrace *)sr_js_stacktrace_parse(
@@ -832,7 +832,7 @@ sr_abrt_report_from_dir(const char *directory,
                 &location);
         }
 
-        free(backtrace_contents);
+        g_free(backtrace_contents);
         if (!report->stacktrace)
         {
             *error_message = sr_location_to_string(&location);

--- a/lib/callgraph.c
+++ b/lib/callgraph.c
@@ -33,7 +33,7 @@ sr_callgraph_compute(struct sr_disasm_state *disassembler,
     struct sr_callgraph *result = NULL, *last = NULL;
     while (fde_entry)
     {
-        struct sr_callgraph *entry = malloc(sizeof(struct sr_callgraph));
+        struct sr_callgraph *entry = g_malloc(sizeof(*entry));
         entry->address = fde_entry->start_address;
         entry->callees = NULL;
         entry->next = NULL;
@@ -91,7 +91,7 @@ sr_callgraph_extend(struct sr_callgraph *callgraph,
     }
 
     struct sr_callgraph *last = sr_callgraph_last(callgraph);
-    struct sr_callgraph *entry = malloc(sizeof(struct sr_callgraph));
+    struct sr_callgraph *entry = g_malloc(sizeof(*entry));
     entry->address = fde->exec_base + fde->start_address;
     entry->callees = NULL;
     entry->next = NULL;

--- a/lib/callgraph.c
+++ b/lib/callgraph.c
@@ -47,7 +47,7 @@ sr_callgraph_compute(struct sr_disasm_state *disassembler,
         if (!instructions)
         {
             sr_callgraph_free(result);
-            free(entry);
+            g_free(entry);
             return NULL;
         }
 
@@ -104,7 +104,7 @@ sr_callgraph_extend(struct sr_callgraph *callgraph,
 
     if (!instructions)
     {
-        free(entry);
+        g_free(entry);
         return NULL;
     }
 
@@ -132,7 +132,7 @@ sr_callgraph_extend(struct sr_callgraph *callgraph,
             callgraph = result;
         else if (*error_message)
         {
-            free(*error_message);
+            g_free(*error_message);
             *error_message = NULL;
         }
 
@@ -150,8 +150,8 @@ sr_callgraph_free(struct sr_callgraph *callgraph)
     {
         struct sr_callgraph *entry = callgraph;
         callgraph = entry->next;
-        free(entry->callees);
-        free(entry);
+        g_free(entry->callees);
+        g_free(entry);
     }
 }
 

--- a/lib/cluster.c
+++ b/lib/cluster.c
@@ -45,9 +45,9 @@ sr_dendrogram_free(struct sr_dendrogram *dendrogram)
 {
     if (!dendrogram)
         return;
-    free(dendrogram->order);
-    free(dendrogram->merge_levels);
-    free(dendrogram);
+    g_free(dendrogram->order);
+    g_free(dendrogram->merge_levels);
+    g_free(dendrogram);
 }
 
 struct cluster
@@ -67,7 +67,7 @@ cluster_init(struct cluster *cluster)
 static void
 cluster_clean(struct cluster *cluster)
 {
-    free(cluster->objects);
+    g_free(cluster->objects);
     cluster_init(cluster);
 }
 
@@ -281,8 +281,8 @@ sr_cluster_free(struct sr_cluster *cluster)
 {
     if (!cluster)
         return;
-    free(cluster->objects);
-    free(cluster);
+    g_free(cluster->objects);
+    g_free(cluster);
 }
 
 struct sr_cluster *

--- a/lib/core_frame.c
+++ b/lib/core_frame.c
@@ -84,11 +84,11 @@ sr_core_frame_free(struct sr_core_frame *frame)
     if (!frame)
         return;
 
-    free(frame->build_id);
-    free(frame->function_name);
-    free(frame->file_name);
-    free(frame->fingerprint);
-    free(frame);
+    g_free(frame->build_id);
+    g_free(frame->function_name);
+    g_free(frame->file_name);
+    g_free(frame->fingerprint);
+    g_free(frame);
 }
 
 struct sr_core_frame *

--- a/lib/core_stacktrace.c
+++ b/lib/core_stacktrace.c
@@ -101,9 +101,9 @@ sr_core_stacktrace_free(struct sr_core_stacktrace *stacktrace)
     }
 
     if (stacktrace->executable)
-        free(stacktrace->executable);
+        g_free(stacktrace->executable);
 
-    free(stacktrace);
+    g_free(stacktrace);
 }
 
 struct sr_core_stacktrace *
@@ -287,8 +287,8 @@ sr_core_stacktrace_to_json(struct sr_core_stacktrace *stacktrace)
         char *indented_thread_json = sr_indent_except_first_line(thread_json, 8);
 
         g_string_append(strbuf, indented_thread_json);
-        free(indented_thread_json);
-        free(thread_json);
+        g_free(indented_thread_json);
+        g_free(thread_json);
         thread = thread->next;
         if (thread)
             g_string_append(strbuf, "\n");

--- a/lib/core_thread.c
+++ b/lib/core_thread.c
@@ -84,7 +84,7 @@ sr_core_thread_free(struct sr_core_thread *thread)
         sr_core_frame_free(frame);
     }
 
-    free(thread);
+    g_free(thread);
 }
 
 struct sr_core_thread *
@@ -247,8 +247,8 @@ sr_core_thread_to_json(struct sr_core_thread *thread, bool is_crash_thread)
             char *frame_json = sr_core_frame_to_json(frame);
             char *indented_frame_json = sr_indent_except_first_line(frame_json, 8);
             g_string_append(strbuf, indented_frame_json);
-            free(indented_frame_json);
-            free(frame_json);
+            g_free(indented_frame_json);
+            g_free(frame_json);
             frame = frame->next;
             if (frame)
                 g_string_append(strbuf, "\n");

--- a/lib/core_unwind.c
+++ b/lib/core_unwind.c
@@ -112,10 +112,10 @@ core_handle_free(struct core_handle *ch)
         struct exe_mapping_data *seg = ch->segments, *next;
         while (seg)
         {
-            free(seg->filename);
+            g_free(seg->filename);
 
             next = seg->next;
-            free(seg);
+            g_free(seg);
             seg = next;
         }
 
@@ -125,7 +125,7 @@ core_handle_free(struct core_handle *ch)
             elf_end(ch->eh);
         if (ch->fd > 0)
             close(ch->fd);
-        free(ch);
+        g_free(ch);
     }
 }
 
@@ -283,7 +283,7 @@ fail_elf:
 fail_close:
     close(ch->fd);
 fail_free:
-    free(ch);
+    g_free(ch);
 
     return NULL;
 }

--- a/lib/core_unwind_elfutils.c
+++ b/lib/core_unwind_elfutils.c
@@ -196,7 +196,7 @@ sr_parse_coredump(const char *core_file,
         else if (ret == DWARF_CB_ABORT)
         {
             set_error("%s", thread_arg.error_msg);
-            free(thread_arg.error_msg);
+            g_free(thread_arg.error_msg);
         }
         else
             set_error("Unknown error in dwfl_getthreads");
@@ -232,7 +232,7 @@ sr_core_stacktrace_unwind_state_free(struct sr_core_stracetrace_unwind_state *st
         state->dwfl = NULL;
     }
 
-    free(state);
+    g_free(state);
 }
 
 struct sr_core_stracetrace_unwind_state *
@@ -349,7 +349,7 @@ sr_core_stacktrace_from_core_hook_generate(pid_t tid,
         else if (ret == DWARF_CB_ABORT)
         {
             set_error("%s", frame_arg.error_msg);
-            free(frame_arg.error_msg);
+            g_free(frame_arg.error_msg);
         }
         else
             set_error("Unknown error in dwfl_getthreads");

--- a/lib/core_unwind_libunwind.c
+++ b/lib/core_unwind_libunwind.c
@@ -72,7 +72,7 @@ unwind_thread(struct UCD_info *ui,
             if (unw_get_proc_name(&c, funcname, funcname_len, NULL) == 0)
                 entry->function_name = funcname;
             else
-                free(funcname);
+                g_free(funcname);
         }
 
         trace = sr_core_frame_append(trace, entry);

--- a/lib/disasm.c
+++ b/lib/disasm.c
@@ -160,7 +160,7 @@ sr_disasm_get_callee_addresses(char **instructions)
     }
 
     /* Create the output array and fill it */
-    uint64_t *result = malloc(result_size * sizeof(uint64_t) + 1);
+    uint64_t *result = g_malloc(result_size * sizeof(*result) + 1);
     size_t result_offset = 0;
     instruction_offset = 0;
     while (instructions[instruction_offset])

--- a/lib/distance.c
+++ b/lib/distance.c
@@ -265,8 +265,8 @@ distance_levenshtein(struct sr_thread *thread1,
     }
 
     int result = dist[n];
-    free(dist);
-    free(dist1);
+    g_free(dist);
+    g_free(dist1);
 
     return (float)result / max_frame_count;
 }
@@ -353,8 +353,8 @@ sr_distances_free(struct sr_distances *distances)
     if (!distances)
         return;
 
-    free(distances->distances);
-    free(distances);
+    g_free(distances->distances);
+    g_free(distances);
 }
 
 float
@@ -691,9 +691,9 @@ sr_distances_part_free(struct sr_distances_part *part, bool follow_links)
     struct sr_distances_part *next = part->next;
 
     if (part->distances)
-        free(part->distances);
+        g_free(part->distances);
 
-    free(part);
+    g_free(part);
 
     if (follow_links)
         sr_distances_part_free(next, true);

--- a/lib/elves.c
+++ b/lib/elves.c
@@ -49,7 +49,7 @@
  *   Save the section header here. Cannot be NULL.
  * @param error_message
  *   Will be filled by an error message if the function fails (returns
- *   zero).  Caller is responsible for calling free() on the string
+ *   zero).  Caller is responsible for calling g_free() on the string
  *   pointer.  If function succeeds, the pointer is not touched by the
  *   function.
  * @returns
@@ -158,7 +158,7 @@ sr_elf_get_procedure_linkage_table(const char *filename,
                                      filename,
                                      find_section_error_message);
 
-        free(find_section_error_message);
+        g_free(find_section_error_message);
         elf_end(elf);
         close(fd);
         return NULL;
@@ -334,8 +334,8 @@ sr_elf_procedure_linkage_table_free(struct sr_elf_plt_entry *entries)
     {
         struct sr_elf_plt_entry *entry = entries;
         entries = entry->next;
-        free(entry->symbol_name);
-        free(entry);
+        g_free(entry->symbol_name);
+        g_free(entry);
     }
 }
 
@@ -395,7 +395,7 @@ cie_free(struct cie *entries)
     {
         struct cie *entry = entries;
         entries = entry->next;
-        free(entry);
+        g_free(entry);
     }
 }
 
@@ -433,7 +433,7 @@ read_cie(Dwarf_CFI_Entry *cfi,
             {
                 *error_message = g_strdup_printf("Unknown FDE encoding (CIE %jx)",
                                              (uintmax_t)cfi_offset);
-                free(cie);
+                g_free(cie);
                 return NULL;
             }
 
@@ -452,7 +452,7 @@ read_cie(Dwarf_CFI_Entry *cfi,
                 *error_message = g_strdup_printf("Unknown size for personality encoding (CIE %jx)",
                                              (uintmax_t)cfi_offset);
 
-                free(cie);
+                g_free(cie);
                 return NULL;
             }
 
@@ -462,7 +462,7 @@ read_cie(Dwarf_CFI_Entry *cfi,
         default:
             *error_message = g_strdup_printf("Unknown augmentation char (CIE %jx)",
                                          (uintmax_t)cfi_offset);
-            free(cie);
+            g_free(cie);
             return NULL;
         }
 
@@ -547,7 +547,7 @@ sr_elf_get_eh_frame(const char *filename,
                                      filename,
                                      find_section_error_message);
 
-        free(find_section_error_message);
+        g_free(find_section_error_message);
         elf_end(elf);
         close(fd);
         return NULL;
@@ -673,7 +673,7 @@ sr_elf_get_eh_frame(const char *filename,
                                              filename,
                                              cie_error_message);
 
-                free(cie_error_message);
+                g_free(cie_error_message);
                 cie_free(cie_list);
                 sr_elf_eh_frame_free(result);
                 elf_end(elf);
@@ -786,7 +786,7 @@ sr_elf_eh_frame_free(struct sr_elf_fde *entries)
     {
         struct sr_elf_fde *entry = entries;
         entries = entry->next;
-        free(entry);
+        g_free(entry);
     }
 }
 
@@ -863,8 +863,8 @@ sr_elf_fde_to_json(struct sr_elf_fde *fde,
             char *fde_json = sr_elf_fde_to_json(loop, false);
             char *indented_fde_json = sr_indent_except_first_line(fde_json, 2);
             g_string_append(strbuf, indented_fde_json);
-            free(indented_fde_json);
-            free(fde_json);
+            g_free(indented_fde_json);
+            g_free(fde_json);
             loop = loop->next;
             if (loop)
                 g_string_append(strbuf, "\n");

--- a/lib/elves.h
+++ b/lib/elves.h
@@ -77,7 +77,7 @@ struct sr_elf_fde
  * Reads the Procedure Linkage Table from an ELF file.
  * @param error_message
  *   Will be filled by an error message if the function fails (returns
- *   NULL).  Caller is responsible for calling free() on the string
+ *   NULL).  Caller is responsible for calling g_free() on the string
  *   pointer.  If function succeeds, the pointer is not touched by the
  *   function.
  * @returns
@@ -98,7 +98,7 @@ sr_elf_plt_find_for_address(struct sr_elf_plt_entry *plt,
  * Reads the .eh_frame section from an ELF file.
  * @param error_message
  *   Will be filled by an error message if the function fails (returns
- *   NULL).  Caller is responsible for calling free() on the string
+ *   NULL).  Caller is responsible for calling g_free() on the string
  *   pointer.  If function succeeds, the pointer is not touched by the
  *   function.
  * @returns

--- a/lib/gdb_frame.c
+++ b/lib/gdb_frame.c
@@ -93,11 +93,11 @@ sr_gdb_frame_free(struct sr_gdb_frame *frame)
     if (!frame)
         return;
 
-    free(frame->function_name);
-    free(frame->function_type);
-    free(frame->source_file);
-    free(frame->library_name);
-    free(frame);
+    g_free(frame->function_name);
+    g_free(frame->function_type);
+    g_free(frame->source_file);
+    g_free(frame->library_name);
+    g_free(frame);
 }
 
 struct sr_gdb_frame *
@@ -530,7 +530,7 @@ sr_gdb_frame_parse_function_name_braces(const char **input, char **target)
             0 < sr_gdb_frame_parse_function_name_template(&local_input, &namechunk))
         {
             g_string_append(buf, namechunk);
-            free(namechunk);
+            g_free(namechunk);
         }
         else
             break;
@@ -576,7 +576,7 @@ sr_gdb_frame_parse_function_name_template(const char **input, char **target)
             0 < sr_gdb_frame_parse_function_name_template(&local_input, &namechunk))
         {
             g_string_append(buf, namechunk);
-            free(namechunk);
+            g_free(namechunk);
         }
         else
             break;
@@ -641,7 +641,7 @@ sr_gdb_frame_parse_function_name(const char **input,
         if (0 < chars)
         {
             g_string_append(buf0, namechunk);
-            free(namechunk);
+            g_free(namechunk);
             location->column += chars;
         }
         else
@@ -676,7 +676,7 @@ sr_gdb_frame_parse_function_name(const char **input,
             break;
 
         g_string_append(buf0, namechunk);
-        free(namechunk);
+        g_free(namechunk);
         location->column += chars;
     }
 
@@ -722,7 +722,7 @@ sr_gdb_frame_parse_function_name(const char **input,
 
         buf1 = g_string_new(NULL);
         g_string_append(buf1, namechunk);
-        free(namechunk);
+        g_free(namechunk);
         location->column += chars;
 
         /* The rest consists of a function name parts, braces, templates...*/
@@ -746,7 +746,7 @@ sr_gdb_frame_parse_function_name(const char **input,
                 break;
 
             g_string_append(buf1, namechunk);
-            free(namechunk);
+            g_free(namechunk);
             location->column += chars;
         }
 
@@ -896,8 +896,8 @@ sr_gdb_frame_parse_function_call(const char **input,
                                         &line,
                                         &column))
     {
-        free(name);
-        free(type);
+        g_free(name);
+        g_free(type);
         location->message = "Expected a space or newline after the function name.";
         return false;
     }
@@ -906,8 +906,8 @@ sr_gdb_frame_parse_function_call(const char **input,
 
     if (!sr_gdb_frame_skip_function_args(&local_input, location))
     {
-        free(name);
-        free(type);
+        g_free(name);
+        g_free(type);
         /* The location message is set by the function returning
          * false, no need to update it here. */
         return false;
@@ -1059,7 +1059,7 @@ sr_gdb_frame_parse_file_location(const char **input,
     if((tmp = strstr(file_name, "/lib")) != NULL
        && (strstr(tmp, ".so.") != NULL
            || strcmp(tmp + strlen(tmp) - 3, ".so") == 0)) {
-        free(file_name);
+        g_free(file_name);
         file_name = NULL;
     }
 
@@ -1070,7 +1070,7 @@ sr_gdb_frame_parse_file_location(const char **input,
         location->column += digits;
         if (0 == digits)
         {
-            free(file_name);
+            g_free(file_name);
             location->message = "Expected a line number.";
             return false;
         }

--- a/lib/gdb_sharedlib.c
+++ b/lib/gdb_sharedlib.c
@@ -48,8 +48,8 @@ sr_gdb_sharedlib_free(struct sr_gdb_sharedlib *sharedlib)
     if (!sharedlib)
         return;
 
-    free(sharedlib->soname);
-    free(sharedlib);
+    g_free(sharedlib->soname);
+    g_free(sharedlib);
 }
 
 struct sr_gdb_sharedlib *

--- a/lib/gdb_stacktrace.c
+++ b/lib/gdb_stacktrace.c
@@ -116,7 +116,7 @@ sr_gdb_stacktrace_free(struct sr_gdb_stacktrace *stacktrace)
     if (stacktrace->crash)
         sr_gdb_frame_free(stacktrace->crash);
 
-    free(stacktrace);
+    g_free(stacktrace);
 }
 
 struct sr_gdb_stacktrace *

--- a/lib/gdb_thread.c
+++ b/lib/gdb_thread.c
@@ -93,7 +93,7 @@ sr_gdb_thread_free(struct sr_gdb_thread *thread)
         sr_gdb_frame_free(frame);
     }
 
-    free(thread);
+    g_free(thread);
 }
 
 struct sr_gdb_thread *
@@ -546,7 +546,7 @@ sr_gdb_thread_set_libnames(struct sr_gdb_thread *thread, struct sr_gdb_sharedlib
                 s2 += strlen(".so");
 
             if (frame->library_name)
-                free(frame->library_name);
+                g_free(frame->library_name);
             frame->library_name = g_strndup(s1, s2 - s1);
         }
         frame = frame->next;

--- a/lib/java_frame.c
+++ b/lib/java_frame.c
@@ -95,11 +95,11 @@ sr_java_frame_free(struct sr_java_frame *frame)
     if (!frame)
         return;
 
-    free(frame->file_name);
-    free(frame->name);
-    free(frame->class_path);
-    free(frame->message);
-    free(frame);
+    g_free(frame->file_name);
+    g_free(frame->name);
+    g_free(frame->class_path);
+    g_free(frame->message);
+    g_free(frame);
 }
 
 void

--- a/lib/java_stacktrace.c
+++ b/lib/java_stacktrace.c
@@ -91,7 +91,7 @@ sr_java_stacktrace_free(struct sr_java_stacktrace *stacktrace)
         sr_java_thread_free(thread);
     }
 
-    free(stacktrace);
+    g_free(stacktrace);
 }
 
 struct sr_java_stacktrace *
@@ -180,8 +180,8 @@ sr_java_stacktrace_to_json(struct sr_java_stacktrace *stacktrace)
         char *thread_json = sr_java_thread_to_json(thread);
         char *indented_thread_json = sr_indent_except_first_line(thread_json, 8);
         g_string_append(strbuf, indented_thread_json);
-        free(indented_thread_json);
-        free(thread_json);
+        g_free(indented_thread_json);
+        g_free(thread_json);
         thread = thread->next;
         if (thread)
             g_string_append(strbuf, "\n");

--- a/lib/java_thread.c
+++ b/lib/java_thread.c
@@ -88,8 +88,8 @@ sr_java_thread_free(struct sr_java_thread *thread)
 
     sr_java_frame_free_full(thread->frames);
 
-    free(thread->name);
-    free(thread);
+    g_free(thread->name);
+    g_free(thread);
 }
 
 struct sr_java_thread *
@@ -388,8 +388,8 @@ sr_java_thread_to_json(struct sr_java_thread *thread)
             char *frame_json = sr_java_frame_to_json(frame);
             char *indented_frame_json = sr_indent_except_first_line(frame_json, 8);
             g_string_append(strbuf, indented_frame_json);
-            free(indented_frame_json);
-            free(frame_json);
+            g_free(indented_frame_json);
+            g_free(frame_json);
             frame = frame->next;
             if (frame)
                 g_string_append(strbuf, "\n");

--- a/lib/js_frame.c
+++ b/lib/js_frame.c
@@ -85,9 +85,9 @@ sr_js_frame_free(struct sr_js_frame *frame)
     if (!frame)
         return;
 
-    free(frame->file_name);
-    free(frame->function_name);
-    free(frame);
+    g_free(frame->file_name);
+    g_free(frame->function_name);
+    g_free(frame);
 }
 
 struct sr_js_frame *

--- a/lib/js_platform.c
+++ b/lib/js_platform.c
@@ -234,8 +234,8 @@ sr_js_platform_from_json(json_object *root, char **error_message)
     sr_js_platform_init(platform, engine, runtime);
 
 fail:
-    free(engine_str);
-    free(runtime_str);
+    g_free(engine_str);
+    g_free(runtime_str);
     return platform;
 }
 

--- a/lib/js_stacktrace.c
+++ b/lib/js_stacktrace.c
@@ -108,8 +108,8 @@ sr_js_stacktrace_free(struct sr_js_stacktrace *stacktrace)
         sr_js_frame_free(frame);
     }
 
-    free(stacktrace->exception_name);
-    free(stacktrace);
+    g_free(stacktrace->exception_name);
+    g_free(stacktrace);
 }
 
 struct sr_js_stacktrace *
@@ -264,8 +264,8 @@ sr_js_stacktrace_to_json(struct sr_js_stacktrace *stacktrace)
             char *frame_json = sr_js_frame_to_json(frame);
             char *indented_frame_json = sr_indent_except_first_line(frame_json, 8);
             g_string_append(strbuf, indented_frame_json);
-            free(indented_frame_json);
-            free(frame_json);
+            g_free(indented_frame_json);
+            g_free(frame_json);
             frame = frame->next;
             if (frame)
                 g_string_append(strbuf, "\n");
@@ -281,8 +281,8 @@ sr_js_stacktrace_to_json(struct sr_js_stacktrace *stacktrace)
         char *platform_json = sr_js_platform_to_json(stacktrace->platform);
         char *indented_platform_json = sr_indent_except_first_line(platform_json, 8);
         g_string_append(strbuf, indented_platform_json);
-        free(indented_platform_json);
-        free(platform_json);
+        g_free(indented_platform_json);
+        g_free(platform_json);
     }
 
     if (strbuf->len > 0)

--- a/lib/json_utils.c
+++ b/lib/json_utils.c
@@ -113,7 +113,7 @@ sr_json_append_escaped(GString *strbuf, const char *str)
     g_string_append_c(strbuf, '\"');
     g_string_append(strbuf, escaped_str);
     g_string_append_c(strbuf, '\"');
-    free(escaped_str);
+    g_free(escaped_str);
 
     return strbuf;
 }

--- a/lib/koops_frame.c
+++ b/lib/koops_frame.c
@@ -80,12 +80,12 @@ sr_koops_frame_free(struct sr_koops_frame *frame)
     if (!frame)
         return;
 
-    free(frame->function_name);
-    free(frame->module_name);
-    free(frame->from_function_name);
-    free(frame->from_module_name);
-    free(frame->special_stack);
-    free(frame);
+    g_free(frame->function_name);
+    g_free(frame->module_name);
+    g_free(frame->from_function_name);
+    g_free(frame->from_module_name);
+    g_free(frame->special_stack);
+    g_free(frame);
 }
 
 struct sr_koops_frame *
@@ -508,7 +508,7 @@ sr_koops_parse_module_name(const char **input,
 
     if (!sr_skip_char(&local_input, ']'))
     {
-        free(*module_name);
+        g_free(*module_name);
         *module_name = NULL;
         return false;
     }
@@ -553,7 +553,7 @@ sr_koops_parse_function(const char **input,
 
         if (!sr_skip_char(&local_input, '/'))
         {
-            free(*function_name);
+            g_free(*function_name);
             *function_name = NULL;
             return false;
         }
@@ -574,11 +574,11 @@ sr_koops_parse_function(const char **input,
 
     if (parenthesis && !sr_skip_char(&local_input, ')'))
     {
-        free(*function_name);
+        g_free(*function_name);
         *function_name = NULL;
         if (has_module)
         {
-            free(*module_name);
+            g_free(*module_name);
             *module_name = NULL;
         }
 

--- a/lib/koops_stacktrace.c
+++ b/lib/koops_stacktrace.c
@@ -133,10 +133,10 @@ sr_koops_stacktrace_free(struct sr_koops_stacktrace *stacktrace)
 
     g_strfreev(stacktrace->modules);
 
-    free(stacktrace->version);
-    free(stacktrace->raw_oops);
-    free(stacktrace->reason);
-    free(stacktrace);
+    g_free(stacktrace->version);
+    g_free(stacktrace->raw_oops);
+    g_free(stacktrace->reason);
+    g_free(stacktrace);
 }
 
 struct sr_koops_stacktrace *
@@ -320,7 +320,7 @@ parse_alt_stack_start(const char **input)
         !sr_parse_char_cspan(&local_input, "> \t\n", &stack_label) ||
         !sr_skip_char(&local_input, '>'))
     {
-        free(stack_label);
+        g_free(stack_label);
         return NULL;
     }
 
@@ -383,7 +383,7 @@ sr_koops_stacktrace_parse(const char **input,
         /* <IRQ>, <NMI>, ... */
         if (parse_alt_stack_end(&local_input))
         {
-            free(alt_stack);
+            g_free(alt_stack);
             alt_stack = NULL;
         }
 
@@ -409,7 +409,7 @@ next_line:
         sr_skip_char(&local_input, '\n');
     }
     if (alt_stack)
-        free(alt_stack);
+        g_free(alt_stack);
 
     *input = local_input;
     return stacktrace;
@@ -503,7 +503,7 @@ sr_koops_stacktrace_parse_modules(const char **input)
                 }
 
                 char *tmp = g_strdup_printf("%s%s", result[result_offset-1], therest);
-                free(result[result_offset-1]);
+                g_free(result[result_offset-1]);
                 result[result_offset-1] = tmp;
             }
 
@@ -570,9 +570,9 @@ sr_koops_stacktrace_to_json(struct sr_koops_stacktrace *stacktrace)
     /* Kernel taint flags. */
     char *taint_flags = taint_flags_to_json(stacktrace);
     char *indented_taint_flags = sr_indent_except_first_line(taint_flags, strlen(",   \"taint_flags\": "));
-    free(taint_flags);
+    g_free(taint_flags);
     g_string_append_printf(strbuf, ",   \"taint_flags\": %s\n", indented_taint_flags);
-    free(indented_taint_flags);
+    g_free(indented_taint_flags);
 
     /* Modules. */
     if (stacktrace->modules)
@@ -610,8 +610,8 @@ sr_koops_stacktrace_to_json(struct sr_koops_stacktrace *stacktrace)
             char *frame_json = sr_koops_frame_to_json(frame);
             char *indented_frame_json = sr_indent_except_first_line(frame_json, 8);
             g_string_append(strbuf, indented_frame_json);
-            free(indented_frame_json);
-            free(frame_json);
+            g_free(indented_frame_json);
+            g_free(frame_json);
             frame = frame->next;
             if (frame)
                 g_string_append(strbuf, "\n");

--- a/lib/normalize.c
+++ b/lib/normalize.c
@@ -258,7 +258,7 @@ sr_normalize_gdb_thread(struct sr_gdb_thread *thread)
 
         if (new_function_name)
         {
-            free(frame->function_name);
+            g_free(frame->function_name);
             frame->function_name = new_function_name;
         }
 
@@ -394,7 +394,7 @@ sr_normalize_core_thread(struct sr_core_thread *thread)
 
         if (new_function_name)
         {
-            free(frame->function_name);
+            g_free(frame->function_name);
             frame->function_name = new_function_name;
         }
 
@@ -545,9 +545,9 @@ sr_normalize_gdb_paired_unknown_function_names(struct sr_gdb_thread *thread1,
           strcmp(curr_frame1->library_name, curr_frame2->library_name)) &&
         next_functions_similar(curr_frame1, curr_frame2))
     {
-        free(curr_frame1->function_name);
+        g_free(curr_frame1->function_name);
         curr_frame1->function_name = g_strdup_printf("__unknown_function_%d", i);
-        free(curr_frame2->function_name);
+        g_free(curr_frame2->function_name);
         curr_frame2->function_name = g_strdup_printf("__unknown_function_%d", i);
         i++;
     }
@@ -573,9 +573,9 @@ sr_normalize_gdb_paired_unknown_function_names(struct sr_gdb_thread *thread1,
                     !(prev_frame1->library_name && prev_frame2->library_name &&
                       strcmp(prev_frame1->library_name, prev_frame2->library_name)))
                 {
-                    free(curr_frame1->function_name);
+                    g_free(curr_frame1->function_name);
                     curr_frame1->function_name = g_strdup_printf("__unknown_function_%d", i);
-                    free(curr_frame2->function_name);
+                    g_free(curr_frame2->function_name);
                     curr_frame2->function_name = g_strdup_printf("__unknown_function_%d", i);
                     i++;
                     break;

--- a/lib/operating_system.c
+++ b/lib/operating_system.c
@@ -53,13 +53,13 @@ sr_operating_system_free(struct sr_operating_system *operating_system)
     if (!operating_system)
         return;
 
-    free(operating_system->name);
-    free(operating_system->version);
-    free(operating_system->architecture);
-    free(operating_system->cpe);
-    free(operating_system->desktop);
-    free(operating_system->variant);
-    free(operating_system);
+    g_free(operating_system->name);
+    g_free(operating_system->version);
+    g_free(operating_system->architecture);
+    g_free(operating_system->cpe);
+    g_free(operating_system->desktop);
+    g_free(operating_system->variant);
+    g_free(operating_system);
 }
 
 char *
@@ -214,9 +214,9 @@ os_release_callback(char *key, char *value, void *data)
     else if (0 == strcmp(key, "VERSION") && strstr(value, "(Rawhide)"))
     {
         if (operating_system->version)
-            free(operating_system->version);
+            g_free(operating_system->version);
         operating_system->version = g_strdup("rawhide");
-        free(value);
+        g_free(value);
     }
     else if (0 == strcmp(key, "CPE_NAME"))
     {
@@ -228,9 +228,9 @@ os_release_callback(char *key, char *value, void *data)
     }
     else
     {
-        free(value);
+        g_free(value);
     }
-    free(key);
+    g_free(key);
 }
 
 bool

--- a/lib/python_frame.c
+++ b/lib/python_frame.c
@@ -79,10 +79,10 @@ sr_python_frame_free(struct sr_python_frame *frame)
     if (!frame)
         return;
 
-    free(frame->file_name);
-    free(frame->function_name);
-    free(frame->line_contents);
-    free(frame);
+    g_free(frame->file_name);
+    g_free(frame->function_name);
+    g_free(frame->line_contents);
+    g_free(frame);
 }
 
 struct sr_python_frame *
@@ -232,7 +232,7 @@ sr_python_frame_parse(const char **input,
         frame->special_file = true;
         frame->file_name[strlen(frame->file_name)-1] = '\0';
         char *inside = g_strdup(frame->file_name + 1);
-        free(frame->file_name);
+        g_free(frame->file_name);
         frame->file_name = inside;
     }
 
@@ -295,7 +295,7 @@ sr_python_frame_parse(const char **input,
             frame->special_function = true;
             frame->function_name[strlen(frame->function_name)-1] = '\0';
             char *inside = g_strdup(frame->function_name + 1);
-            free(frame->function_name);
+            g_free(frame->function_name);
             frame->function_name = inside;
         }
     }

--- a/lib/python_stacktrace.c
+++ b/lib/python_stacktrace.c
@@ -107,8 +107,8 @@ sr_python_stacktrace_free(struct sr_python_stacktrace *stacktrace)
         sr_python_frame_free(frame);
     }
 
-    free(stacktrace->exception_name);
-    free(stacktrace);
+    g_free(stacktrace->exception_name);
+    g_free(stacktrace);
 }
 
 struct sr_python_stacktrace *
@@ -279,8 +279,8 @@ sr_python_stacktrace_to_json(struct sr_python_stacktrace *stacktrace)
             char *frame_json = sr_python_frame_to_json(frame);
             char *indented_frame_json = sr_indent_except_first_line(frame_json, 8);
             g_string_append(strbuf, indented_frame_json);
-            free(indented_frame_json);
-            free(frame_json);
+            g_free(indented_frame_json);
+            g_free(frame_json);
             frame = frame->next;
             if (frame)
                 g_string_append(strbuf, "\n");

--- a/lib/report.c
+++ b/lib/report.c
@@ -74,7 +74,7 @@ sr_report_init(struct sr_report *report)
 void
 sr_report_free(struct sr_report *report)
 {
-    free(report->component_name);
+    g_free(report->component_name);
     sr_operating_system_free(report->operating_system);
     sr_rpm_package_free(report->rpm_packages, true);
     sr_stacktrace_free(report->stacktrace);
@@ -84,14 +84,14 @@ sr_report_free(struct sr_report *report)
     {
         struct sr_report_custom_entry *tmp = iter->next;
 
-        free(iter->value);
-        free(iter->key);
-        free(iter);
+        g_free(iter->value);
+        g_free(iter->key);
+        g_free(iter);
 
         iter = tmp;
     }
 
-    free(report);
+    g_free(report);
 }
 
 void
@@ -160,7 +160,7 @@ problem_object_string(struct sr_report *report, const char *report_type)
         char *stacktrace = sr_stacktrace_to_json(report->stacktrace);
         dismantle_object(stacktrace);
         g_string_append(strbuf, stacktrace);
-        free(stacktrace);
+        g_free(stacktrace);
     }
 
     g_string_append(strbuf, "}");
@@ -203,7 +203,7 @@ sr_report_to_json(struct sr_report *report)
     g_string_append(strbuf, ",   \"reason\": ");
     sr_json_append_escaped(strbuf, reason);
     g_string_append(strbuf, "\n");
-    free(reason);
+    g_free(reason);
 
     /* Reporter name and version. */
     assert(report->reporter_name);
@@ -213,46 +213,46 @@ sr_report_to_json(struct sr_report *report)
                                  report->reporter_name,
                                  report->reporter_version);
     char *reporter_indented = sr_indent_except_first_line(reporter, strlen(",   \"reporter\": "));
-    free(reporter);
+    g_free(reporter);
     g_string_append_printf(strbuf,
                           ",   \"reporter\": %s\n",
                           reporter_indented);
-    free(reporter_indented);
+    g_free(reporter_indented);
 
     /* Operating system. */
     if (report->operating_system)
     {
         char *opsys_str = sr_operating_system_to_json(report->operating_system);
         char *opsys_str_indented = sr_indent_except_first_line(opsys_str, strlen(",   \"os\": "));
-        free(opsys_str);
+        g_free(opsys_str);
         g_string_append_printf(strbuf,
                               ",   \"os\": %s\n",
                               opsys_str_indented);
 
-        free(opsys_str_indented);
+        g_free(opsys_str_indented);
     }
 
     /* Problem section - stacktrace + other info. */
     char *problem = problem_object_string(report, report_type);
     char *problem_indented = sr_indent_except_first_line(problem, strlen(",   \"problem\": "));
-    free(problem);
-    free(report_type);
+    g_free(problem);
+    g_free(report_type);
     g_string_append_printf(strbuf,
                           ",   \"problem\": %s\n",
                           problem_indented);
-    free(problem_indented);
+    g_free(problem_indented);
 
     /* Packages. (Only RPM supported so far.) */
     if (report->rpm_packages)
     {
         char *rpms_str = sr_rpm_package_to_json(report->rpm_packages, true);
         char *rpms_str_indented = sr_indent_except_first_line(rpms_str, strlen(",   \"packages\": "));
-        free(rpms_str);
+        g_free(rpms_str);
         g_string_append_printf(strbuf,
                               ",   \"packages\": %s\n",
                               rpms_str_indented);
 
-        free(rpms_str_indented);
+        g_free(rpms_str_indented);
     }
     /* If there is no package, attach empty list (packages is a mandatory field) */
     else

--- a/lib/rpm.c
+++ b/lib/rpm.c
@@ -57,15 +57,15 @@ sr_rpm_package_free(struct sr_rpm_package *package,
     if (!package)
         return;
 
-    free(package->name);
-    free(package->version);
-    free(package->release);
-    free(package->architecture);
+    g_free(package->name);
+    g_free(package->version);
+    g_free(package->release);
+    g_free(package->architecture);
     sr_rpm_consistency_free(package->consistency, true);
     if (package->next && recursive)
         sr_rpm_package_free(package->next, true);
 
-    free(package);
+    g_free(package);
 }
 
 int
@@ -199,7 +199,7 @@ sr_rpm_package_sort(struct sr_rpm_package *packages)
     }
 
     struct sr_rpm_package *result = array[0];
-    free(array);
+    g_free(array);
     return result;
 }
 
@@ -481,8 +481,8 @@ sr_rpm_package_to_json(struct sr_rpm_package *package,
             char *package_json = sr_rpm_package_to_json(p, false);
             char *indented_package_json = sr_indent_except_first_line(package_json, 2);
             g_string_append(strbuf, indented_package_json);
-            free(indented_package_json);
-            free(package_json);
+            g_free(indented_package_json);
+            g_free(package_json);
             p = p->next;
             if (p)
                 g_string_append(strbuf, "\n");
@@ -763,14 +763,14 @@ sr_rpm_package_parse_nevra(const char *text,
 
         if (failure)
         {
-            free(epoch_str);
-            free(*release);
-            free(*architecture);
+            g_free(epoch_str);
+            g_free(*release);
+            g_free(*architecture);
             return false;
         }
 
         *epoch = r;
-        free(epoch_str);
+        g_free(epoch_str);
     }
     else
     {
@@ -810,11 +810,11 @@ sr_rpm_consistency_free(struct sr_rpm_consistency *consistency,
     if (!consistency)
         return;
 
-    free(consistency->path);
+    g_free(consistency->path);
     if (consistency->next && recursive)
         sr_rpm_consistency_free(consistency->next, true);
 
-    free(consistency);
+    g_free(consistency);
 }
 
 int

--- a/lib/ruby_frame.c
+++ b/lib/ruby_frame.c
@@ -80,9 +80,9 @@ sr_ruby_frame_free(struct sr_ruby_frame *frame)
     if (!frame)
         return;
 
-    free(frame->file_name);
-    free(frame->function_name);
-    free(frame);
+    g_free(frame->file_name);
+    g_free(frame->function_name);
+    g_free(frame);
 }
 
 struct sr_ruby_frame *
@@ -336,7 +336,7 @@ sr_ruby_frame_parse(const char **input,
 
 fail:
     sr_ruby_frame_free(frame);
-    free(filename_lineno_in);
+    g_free(filename_lineno_in);
     return NULL;
 }
 

--- a/lib/ruby_stacktrace.c
+++ b/lib/ruby_stacktrace.c
@@ -106,8 +106,8 @@ sr_ruby_stacktrace_free(struct sr_ruby_stacktrace *stacktrace)
         sr_ruby_frame_free(frame);
     }
 
-    free(stacktrace->exception_name);
-    free(stacktrace);
+    g_free(stacktrace->exception_name);
+    g_free(stacktrace);
 }
 
 struct sr_ruby_stacktrace *
@@ -219,7 +219,7 @@ sr_ruby_stacktrace_parse(const char **input,
     }
 
     /* Throw away the message, it may contain sensitive data. */
-    free(message_and_class);
+    g_free(message_and_class);
     message_and_class = p = NULL;
 
     /* /some/thing.rb:13:in `method': exception message (Exception::Class)\n\tfrom ...
@@ -265,7 +265,7 @@ sr_ruby_stacktrace_parse(const char **input,
 
 fail:
     sr_ruby_stacktrace_free(stacktrace);
-    free(message_and_class);
+    g_free(message_and_class);
     return NULL;
 }
 
@@ -297,8 +297,8 @@ sr_ruby_stacktrace_to_json(struct sr_ruby_stacktrace *stacktrace)
             char *frame_json = sr_ruby_frame_to_json(frame);
             char *indented_frame_json = sr_indent_except_first_line(frame_json, 8);
             g_string_append(strbuf, indented_frame_json);
-            free(indented_frame_json);
-            free(frame_json);
+            g_free(indented_frame_json);
+            g_free(frame_json);
             frame = frame->next;
             if (frame)
                 g_string_append(strbuf, "\n");

--- a/lib/unstrip.c
+++ b/lib/unstrip.c
@@ -120,10 +120,10 @@ sr_unstrip_free(struct sr_unstrip_entry *entries)
     {
         struct sr_unstrip_entry *entry = entries;
         entries = entry->next;
-        free(entry->build_id);
-        free(entry->file_name);
-        free(entry->mod_name);
-        free(entry);
+        g_free(entry->build_id);
+        g_free(entry->file_name);
+        g_free(entry->mod_name);
+        g_free(entry);
     }
 }
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -192,7 +192,7 @@ sr_file_to_string(const char *filename,
     {
         *error_message = g_strdup_printf("Unable to read from '%s'.", filename);
         close(fd);
-        free(contents);
+        g_free(contents);
         return NULL;
     }
 
@@ -413,7 +413,7 @@ sr_parse_uint32(const char **input, uint32_t *result)
     bool failure = (errno || numstr == endptr || *endptr != '\0'
                     || r > UINT32_MAX);
 
-    free(numstr);
+    g_free(numstr);
     if (failure) /* number too big or some other error */
         return 0;
 
@@ -438,7 +438,7 @@ sr_parse_uint64(const char **input, uint64_t *result)
     unsigned long long result_tmp = strtoull(numstr, &endptr, 10);
     bool failure = (errno || numstr == endptr || *endptr != '\0'
                     || result_tmp == UINT64_MAX);
-    free(numstr);
+    g_free(numstr);
     if (failure) /* number too big or some other error */
         return 0;
     *result = result_tmp;
@@ -487,7 +487,7 @@ sr_parse_hexadecimal_uint64(const char **input, uint64_t *result)
     errno = 0;
     unsigned long long r = strtoull(numstr, &endptr, 16);
     bool failure = (errno || numstr == endptr || *endptr != '\0');
-    free(numstr);
+    g_free(numstr);
     if (failure) /* number too big or some other error */
         return 0;
 
@@ -577,7 +577,7 @@ sr_indent(const char *input, int spaces)
 
     char *indented = sr_indent_except_first_line(input, spaces);
     g_string_append(strbuf, indented);
-    free(indented);
+    g_free(indented);
 
     return g_string_free(strbuf, FALSE);
 }
@@ -740,7 +740,7 @@ anonymize_path(char *orig_path)
         {
             // Join /home/anonymized/ and ^
             new_path = g_strdup_printf("%s%s", ANONYMIZED_PATH, new_path);
-            free(orig_path);
+            g_free(orig_path);
             return new_path;
         }
     }

--- a/python/py_base_frame.c
+++ b/python/py_base_frame.c
@@ -101,7 +101,7 @@ sr_py_base_frame_short_string(PyObject *self, PyObject *args)
     char *str = g_string_free(strbuf, FALSE);
 
     PyObject *result = PyString_FromString(str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_base_stacktrace.c
+++ b/python/py_base_stacktrace.c
@@ -275,7 +275,7 @@ sr_py_single_stacktrace_to_short_text(PyObject *self, PyObject *args)
 
     PyObject *result = PyString_FromString(text);
 
-    free(text);
+    g_free(text);
     return result;
 }
 
@@ -298,7 +298,7 @@ sr_py_multi_stacktrace_to_short_text(PyObject *self, PyObject *args)
 
     PyObject *result = PyString_FromString(text);
 
-    free(text);
+    g_free(text);
     return result;
 }
 
@@ -324,7 +324,7 @@ sr_py_single_stacktrace_get_bthash(PyObject *self, PyObject *args)
     }
 
     PyObject *result = PyString_FromString(hash);
-    free(hash);
+    g_free(hash);
     return result;
 }
 
@@ -348,7 +348,7 @@ sr_py_multi_stacktrace_get_bthash(PyObject *self, PyObject *args)
     }
 
     PyObject *result = PyString_FromString(hash);
-    free(hash);
+    g_free(hash);
     return result;
 }
 

--- a/python/py_cluster.c
+++ b/python/py_cluster.c
@@ -122,7 +122,7 @@ sr_py_dendrogram_str(PyObject *self)
                           this->dendrogram->size);
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_common.c
+++ b/python/py_common.c
@@ -55,7 +55,7 @@ sr_py_setter_string(PyObject *self, PyObject *rhs, void *data)
         return -1;
 
     char *str = MEMB_T(char*, MEMB(self, gsoff->c_struct_offset), gsoff->member_offset);
-    free(str);
+    g_free(str);
     MEMB_T(char*, MEMB(self, gsoff->c_struct_offset), gsoff->member_offset) = g_strdup(newvalue);
 
     return 0;

--- a/python/py_core_frame.c
+++ b/python/py_core_frame.c
@@ -169,7 +169,7 @@ sr_py_core_frame_str(PyObject *self)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_core_stacktrace.c
+++ b/python/py_core_stacktrace.c
@@ -151,7 +151,7 @@ sr_py_core_stacktrace_new(PyTypeObject *object,
         if (!stacktrace)
         {
             PyErr_SetString(PyExc_ValueError, error_msg);
-            free(error_msg);
+            g_free(error_msg);
             return NULL;
         }
     }
@@ -183,7 +183,7 @@ sr_py_core_stacktrace_str(PyObject *self)
                            (ssize_t)(PyList_Size(this->threads)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_core_thread.c
+++ b/python/py_core_thread.c
@@ -129,7 +129,7 @@ sr_py_core_thread_str(PyObject *self)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_gdb_frame.c
+++ b/python/py_gdb_frame.c
@@ -232,7 +232,7 @@ sr_py_gdb_frame_str(PyObject *self)
         g_string_append_printf(buf, " (%s)", this->frame->library_name);
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_gdb_stacktrace.c
+++ b/python/py_gdb_stacktrace.c
@@ -344,7 +344,7 @@ sr_py_gdb_stacktrace_str(PyObject *self)
                            (ssize_t)(PyList_Size(this->threads)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 
@@ -566,6 +566,6 @@ sr_py_gdb_stacktrace_to_short_text(PyObject *self, PyObject *args)
 
     PyObject *result = PyString_FromString(text);
 
-    free(text);
+    g_free(text);
     return result;
 }

--- a/python/py_gdb_thread.c
+++ b/python/py_gdb_thread.c
@@ -176,7 +176,7 @@ sr_py_gdb_thread_str(PyObject *self)
                            (ssize_t)(PyList_Size(this->frames)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_java_frame.c
+++ b/python/py_java_frame.c
@@ -201,7 +201,7 @@ sr_py_java_frame_str(PyObject *self)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_java_stacktrace.c
+++ b/python/py_java_stacktrace.c
@@ -145,7 +145,7 @@ sr_py_java_stacktrace_str(PyObject *self)
                            (ssize_t)(PyList_Size(this->threads)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_java_thread.c
+++ b/python/py_java_thread.c
@@ -169,7 +169,7 @@ sr_py_java_thread_str(PyObject *self)
     g_string_append_printf(buf, " with %zd frames", (ssize_t)(PyList_Size(this->frames)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_js_frame.c
+++ b/python/py_js_frame.c
@@ -187,7 +187,7 @@ sr_py_js_frame_str(PyObject *self)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_js_stacktrace.c
+++ b/python/py_js_stacktrace.c
@@ -180,7 +180,7 @@ sr_py_js_stacktrace_str(PyObject *self)
                          (ssize_t)(PyList_Size(this->frames)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_koops_frame.c
+++ b/python/py_koops_frame.c
@@ -213,7 +213,7 @@ sr_py_koops_frame_str(PyObject *self)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_koops_stacktrace.c
+++ b/python/py_koops_stacktrace.c
@@ -222,7 +222,7 @@ sr_py_koops_stacktrace_str(PyObject *self)
                            (ssize_t)(PyList_Size(this->frames)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_metrics.c
+++ b/python/py_metrics.c
@@ -283,7 +283,7 @@ sr_py_distances_str(PyObject *self)
                            this->distances->m, this->distances->n);
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_operating_system.c
+++ b/python/py_operating_system.c
@@ -155,6 +155,6 @@ sr_py_operating_system_str(PyObject *object)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }

--- a/python/py_python_frame.c
+++ b/python/py_python_frame.c
@@ -187,7 +187,7 @@ sr_py_python_frame_str(PyObject *self)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_python_stacktrace.c
+++ b/python/py_python_stacktrace.c
@@ -165,7 +165,7 @@ sr_py_python_stacktrace_str(PyObject *self)
                            (ssize_t)(PyList_Size(this->frames)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_report.c
+++ b/python/py_report.c
@@ -392,7 +392,7 @@ sr_py_report_new(PyTypeObject *object, PyObject *args, PyObject *kwds)
         if (!report)
         {
             PyErr_SetString(PyExc_ValueError, error_msg);
-            free(error_msg);
+            g_free(error_msg);
             return NULL;
         }
     }
@@ -436,14 +436,14 @@ sr_py_report_str(PyObject *object)
 
     char *type = sr_report_type_to_string(this->report->report_type);
     g_string_append_printf(buf, "Report, type: %s", type);
-    free(type);
+    g_free(type);
 
     if (this->report->component_name)
         g_string_append_printf(buf, ", component: %s", this->report->component_name);
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 
@@ -461,7 +461,7 @@ sr_py_report_get_type(PyObject *self, void *data)
     char *type = sr_report_type_to_string(report->report->report_type);
     PyObject *res = PyString_FromString(type);
 
-    free(type);
+    g_free(type);
     return res;
 }
 
@@ -502,7 +502,7 @@ sr_py_report_to_json(PyObject *self, PyObject *args)
         return NULL;
 
     PyObject *result = PyString_FromString(json);
-    free(json);
+    g_free(json);
     return result;
 }
 

--- a/python/py_rpm_package.c
+++ b/python/py_rpm_package.c
@@ -188,7 +188,7 @@ sr_py_rpm_package_str(PyObject *object)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_ruby_frame.c
+++ b/python/py_ruby_frame.c
@@ -204,7 +204,7 @@ sr_py_ruby_frame_str(PyObject *self)
 
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/python/py_ruby_stacktrace.c
+++ b/python/py_ruby_stacktrace.c
@@ -160,7 +160,7 @@ sr_py_ruby_stacktrace_str(PyObject *self)
                          (ssize_t)(PyList_Size(this->frames)));
     char *str = g_string_free(buf, FALSE);
     PyObject *result = Py_BuildValue("s", str);
-    free(str);
+    g_free(str);
     return result;
 }
 

--- a/satyr.c
+++ b/satyr.c
@@ -96,7 +96,7 @@ abrt_print_report_from_dir(int argc, char **argv)
     if (!success)
     {
         fprintf(stderr, "%s\n", error_message);
-        free(error_message);
+        g_free(error_message);
         exit(1);
     }
 }
@@ -125,7 +125,7 @@ abrt_create_core_stacktrace(int argc, char **argv)
     if (!success)
     {
         fprintf(stderr, "%s\n", error_message);
-        free(error_message);
+        g_free(error_message);
         exit(1);
     }
 }
@@ -200,7 +200,7 @@ debug_normalize(int argc, char **argv)
     sr_gdb_thread_append_to_str(thread, strbuf, false);
     puts(strbuf->str);
 
-    free(text);
+    g_free(text);
     g_string_free(strbuf, TRUE);
 }
 
@@ -342,7 +342,7 @@ debug_unwind_from_hook(int argc, char **argv)
         exit(1);
     }
 
-    free(json);
+    g_free(json);
     sr_core_stacktrace_free(core_stacktrace);
 }
 

--- a/tests/core_stacktrace.c
+++ b/tests/core_stacktrace.c
@@ -193,7 +193,7 @@ test_core_stacktrace_from_json(void)
     full_input = sr_file_to_string("json_files/core-01", NULL);
     core_stacktrace = sr_core_stacktrace_from_json_text(full_input, NULL);
     stacktrace = sr_stacktrace_parse(SR_REPORT_CORE, full_input, NULL);
-    free(full_input);
+    g_free(full_input);
 
     test_core_stacktrace_from_json_check(core_stacktrace);
     test_core_stacktrace_from_json_check((struct sr_core_stacktrace *)stacktrace);

--- a/tests/gdb_frame.c
+++ b/tests/gdb_frame.c
@@ -177,7 +177,7 @@ test_gdb_frame_parse_function_name(void)
           printf("Function name '%s'\n", function_name);
           g_assert_cmpstr(function_name, ==, t[i].input);
           g_assert_null(function_type);
-          free(function_name);
+          g_free(function_name);
           g_assert_cmpuint(*input_with_space, ==, ' ');
         }
         else
@@ -186,7 +186,7 @@ test_gdb_frame_parse_function_name(void)
           g_assert_true(old_input_with_space == input_with_space);
         }
 
-        free(old_input_with_space);
+        g_free(old_input_with_space);
     }
 }
 
@@ -241,10 +241,10 @@ test_gdb_frame_parse_function_name_template_args(void)
 
         if (namechunk != (char *)0xDEADBEEF)
         {
-            free(namechunk);
+            g_free(namechunk);
         }
 
-        free(old_input);
+        g_free(old_input);
     }
 }
 
@@ -383,8 +383,8 @@ test_gdb_frame_parse_function_call(void)
             g_assert_true((!t[i].expected_function_type && !function_type) ||
                           0 == g_strcmp0(t[i].expected_function_type, function_type));
             g_assert_cmpuint(*t[i].input, ==, '\0');
-            free(function_name);
-            free(function_type);
+            g_free(function_name);
+            g_free(function_type);
         }
         else
         {
@@ -436,8 +436,8 @@ test_gdb_frame_parse_address_in_function(void)
             g_assert_cmpstr(function, ==, t[i].expected_function);
             g_assert_cmpuint(address, ==, t[i].expected_address);
             g_assert_cmpuint(*t[i].input, ==, '\0');
-            free(function);
-            free(type);
+            g_free(function);
+            g_free(type);
         }
         else
         {
@@ -494,7 +494,7 @@ test_gdb_frame_parse_file_location(void)
             g_assert_cmpstr(file, ==, t[i].expected_file);
             g_assert_cmpuint(line, ==, t[i].expected_line);
             g_assert_cmpuint(*t[i].input, ==, '\0');
-            free(file);
+            g_free(file);
         }
         else
         {

--- a/tests/gdb_stacktrace.c
+++ b/tests/gdb_stacktrace.c
@@ -98,7 +98,7 @@ test_gdb_stacktrace_find_crash_thread(void)
         g_assert_true(crash_thread == crash_thread2);
 
         sr_gdb_stacktrace_free(stacktrace);
-        free(full_input);
+        g_free(full_input);
     }
 }
 

--- a/tests/java_frame.c
+++ b/tests/java_frame.c
@@ -65,12 +65,12 @@ test_java_frame_cmp(void)
     g_assert_cmpint(sr_java_frame_cmp(frames[1], exception_frames[1]), !=, 0);
     g_assert_cmpint(sr_java_frame_cmp(exception_frames[0], frames[0]), !=, 0);
 
-    free(exception_frames[1]->message);
+    g_free(exception_frames[1]->message);
     exception_frames[1]->message = NULL;
 
     g_assert_cmpint(sr_java_frame_cmp(exception_frames[0], exception_frames[1]), ==, 0);
 
-    free(exception_frames[1]->name);
+    g_free(exception_frames[1]->name);
     exception_frames[1]->name = g_strdup("com.sun.java.InvalidOperation");
 
     g_assert_cmpint(sr_java_frame_cmp(exception_frames[0], exception_frames[1]), !=, 0);
@@ -263,12 +263,12 @@ test_java_frame_append_to_str(void)
     test_java_frame_append_to_str_check(exception_frame,
                                         "com.sun.java.NullPointer: Null pointer exception");
 
-    g_clear_pointer(&exception_frame->message, free);
+    g_clear_pointer(&exception_frame->message, g_free);
 
     test_java_frame_append_to_str_check(exception_frame,
                                         "com.sun.java.NullPointer");
 
-    g_clear_pointer(&exception_frame->name, free);
+    g_clear_pointer(&exception_frame->name, g_free);
 
     test_java_frame_append_to_str_check(exception_frame, "");
 
@@ -749,7 +749,7 @@ test_java_frame_parse_exception(void)
         sr_java_frame_free(exception_frames[1]);
         sr_java_frame_free(frame1);
         sr_java_frame_free(exception_frames[0]);
-        free(frame);
+        g_free(frame);
     }
     
 }

--- a/tests/java_thread.c
+++ b/tests/java_thread.c
@@ -31,7 +31,7 @@ test_java_thread_cmp(void)
 
     threads[1] = create_real_main_thread_objects();
 
-    free(threads[1]->name);
+    g_free(threads[1]->name);
     threads[1]->name = g_strdup("worker");
 
     g_assert_cmpint(sr_java_thread_cmp(threads[0], threads[1]), !=, 0);

--- a/tests/js_frame.c
+++ b/tests/js_frame.c
@@ -231,17 +231,17 @@ test_js_frame_cmp(void)
 
     frame2->line_column = frame1->line_column;
 
-    free(frame2->function_name);
+    g_free(frame2->function_name);
     frame2->function_name = NULL;
     g_assert_true(0 != sr_js_frame_cmp(frame1, frame2) || !"function_name - NULL");
 
     frame2->function_name = g_strdup("foo_blah");
     g_assert_true(0 != sr_js_frame_cmp(frame1, frame2) || !"function_name");
 
-    free(frame2->function_name);
+    g_free(frame2->function_name);
     frame2->function_name = g_strdup(frame1->function_name);
 
-    free(frame2->file_name);
+    g_free(frame2->file_name);
     frame2->file_name = NULL;
     g_assert_true(0 != sr_js_frame_cmp(frame1, frame2) || !"file_name - NULL");
 
@@ -281,17 +281,17 @@ test_js_frame_cmp_distance(void)
     g_assert_true(0 == sr_js_frame_cmp_distance(frame1, frame2) || !"line_column");
     frame2->line_column = frame1->line_column;
 
-    free(frame2->function_name);
+    g_free(frame2->function_name);
     frame2->function_name = NULL;
     g_assert_true(0 != sr_js_frame_cmp_distance(frame1, frame2) || !"function_name - NULL");
 
     frame2->function_name = g_strdup("foo_blah");
     g_assert_true(0 != sr_js_frame_cmp_distance(frame1, frame2) || !"function_name");
 
-    free(frame2->function_name);
+    g_free(frame2->function_name);
     frame2->function_name = g_strdup(frame1->function_name);
 
-    free(frame2->file_name);
+    g_free(frame2->file_name);
     frame2->file_name = NULL;
     g_assert_true(0 != sr_js_frame_cmp_distance(frame1, frame2) || !"file_name - NULL");
 
@@ -362,7 +362,7 @@ test_js_frame_to_json(void)
       g_assert_false("Invalid JSON for JavaScript frame");
     }
 
-    free(json);
+    g_free(json);
 }
 
 static void
@@ -391,7 +391,7 @@ test_js_frame_from_json(void)
 
     sr_js_frame_free(frame2);
     json_object_put(root);
-    free(json);
+    g_free(json);
     sr_js_frame_free(frame1);
 }
 

--- a/tests/js_platform.c
+++ b/tests/js_platform.c
@@ -134,7 +134,7 @@ test_js_platform_basics(void)
                 g_assert_true(!"Got invalid error message: sr_js_platform_from_string(" \
                         #i_runtime_str "," #i_version_str ")"); \
             } \
-            free(r_error_message); \
+            g_free(r_error_message); \
         } \
     } while (0)
 
@@ -181,7 +181,7 @@ test_js_platform_from_string(void)
             fprintf(stderr, "%s\n!=\n%s\n", r_json, e_json); \
             g_assert_true(!"sr_js_platform_to_json(("#i_runtime","#i_engine"))");\
         } \
-        free(r_json); \
+        g_free(r_json); \
     } while (0)
 
 static void
@@ -257,7 +257,7 @@ test_js_platform_to_json(void)
                 g_assert_true(!"Got invalid error message: sr_js_platform_from_json(" \
                         #i_json_str ")"); \
             } \
-            free(r_error_message); \
+            g_free(r_error_message); \
         } \
     } while (0)
 

--- a/tests/js_stacktrace.c
+++ b/tests/js_stacktrace.c
@@ -75,7 +75,7 @@ check_valid(char *filename, char *exc_name, unsigned frame_count,
     }
 
     sr_js_stacktrace_free(stacktrace);
-    free(file_contents);
+    g_free(file_contents);
 }
 
 void
@@ -224,7 +224,7 @@ test_js_stacktrace_dup(void)
         
         sr_js_stacktrace_free(stacktrace1);
         sr_js_stacktrace_free(stacktrace2);
-        free(file_contents);
+        g_free(file_contents);
     }
 }
 
@@ -236,7 +236,7 @@ check1(struct sr_js_stacktrace *stacktrace, const char *expected)
         fprintf(stderr, "reason -> '%s' != '%s'\n", reason, expected);
         g_assert_true(!"Invalid reason");
     }
-    free(reason);
+    g_free(reason);
 }
 
 static void
@@ -263,7 +263,7 @@ test_js_stacktrace_get_reason(void)
         check1(stacktrace1, "ReferenceError at /tmp/index.js:2:1");
 
         sr_js_stacktrace_free(stacktrace1);
-        free(file_contents);
+        g_free(file_contents);
     }
     {
         struct sr_js_stacktrace *stacktrace = sr_js_stacktrace_new();
@@ -322,10 +322,10 @@ test_js_stacktrace_to_json(void)
             abort();
         }
         
-        free(json);
-        free(expected);
+        g_free(json);
+        g_free(expected);
         sr_js_stacktrace_free(stacktrace);
-        free(file_contents);
+        g_free(file_contents);
     }
 }
 
@@ -406,9 +406,9 @@ test_js_stacktrace_from_json(void)
         }
         
         sr_js_stacktrace_free(stacktrace2);
-        free(json_file_contents);
+        g_free(json_file_contents);
         sr_js_stacktrace_free(stacktrace1);
-        free(file_contents);
+        g_free(file_contents);
     }
 }
 

--- a/tests/koops_stacktrace.c
+++ b/tests/koops_stacktrace.c
@@ -40,11 +40,11 @@ test_koops_stacktrace_parse_modules(void)
             offset = 0;
             while (modules[offset])
             {
-                free(modules[offset]);
+                g_free(modules[offset]);
                 ++offset;
             }
 
-            free(modules);
+            g_free(modules);
         }
         else
         {
@@ -161,8 +161,8 @@ test_koops_stacktrace_parse(void)
         char *reason2 = sr_stacktrace_get_reason((struct sr_stacktrace *)stacktrace);
         g_assert_nonnull(reason2);
         g_assert_cmpstr(reason, ==, reason2);
-        free(reason);
-        free(reason2);
+        g_free(reason);
+        g_free(reason2);
 
         int actual_taint_count =
           stacktrace->taint_module_proprietary +
@@ -207,13 +207,13 @@ test_koops_stacktrace_parse(void)
         g_assert_true(reason && reason2);
         g_assert_cmpstr(reason, ==, reason2);
 
-        free(reason);
-        free(reason2);
+        g_free(reason);
+        g_free(reason2);
 
         sr_stacktrace_free(stacktrace2);
 
         sr_koops_stacktrace_free(stacktrace);
-        free(full_input);
+        g_free(full_input);
     }
 }
 
@@ -234,7 +234,7 @@ test_koops_stacktrace_to_json(void)
 
     g_assert_nonnull(stacktrace);
     g_assert_cmpint(*input, ==, '\0');
-    free(full_input);
+    g_free(full_input);
 
     char *json = sr_koops_stacktrace_to_json(stacktrace);
     puts(json);
@@ -678,10 +678,10 @@ test_koops_stacktrace_to_json(void)
 
     char *json2 = sr_stacktrace_to_json((struct sr_stacktrace *)stacktrace);
     g_assert_cmpstr(json, ==, json2);
-    free(json2);
+    g_free(json2);
 
     sr_koops_stacktrace_free(stacktrace);
-    free(json);
+    g_free(json);
 }
 
 void generate_and_test(struct sr_thread *thread, int flags, const char *expected)
@@ -766,7 +766,7 @@ test_koops_stacktrace_get_reason(void)
 
     g_assert_nonnull(stacktrace);
     g_assert_cmpint(*input, ==, '\0');
-    free(full_input);
+    g_free(full_input);
 
     char *expected_reason = "general protection fault in find_get_entry";
     g_autofree char *actual_reason = sr_koops_stacktrace_get_reason(stacktrace);

--- a/tests/metrics.c
+++ b/tests/metrics.c
@@ -116,7 +116,7 @@ distance_test_data_free(DistanceTestData *data)
         sr_gdb_thread_free(data->threads[i]);
     }
 
-    free(data);
+    g_free(data);
 }
 
 static void

--- a/tests/ruby_stacktrace.c
+++ b/tests/ruby_stacktrace.c
@@ -128,7 +128,7 @@ test_ruby_stacktrace_parse(void)
         }
 
         sr_ruby_stacktrace_free(stacktrace);
-        free((void *)file_contents);
+        g_free((void *)file_contents);
     }
 }
 
@@ -170,7 +170,7 @@ test_ruby_stacktrace_dup(void)
 
         sr_ruby_stacktrace_free(stacktrace1);
         sr_ruby_stacktrace_free(stacktrace2);
-        free((void *)file_contents);
+        g_free((void *)file_contents);
     }
 }
 
@@ -189,7 +189,7 @@ test_ruby_stacktrace_get_reason(void)
     g_assert_cmpstr(reason, ==, expected);
 
     sr_ruby_stacktrace_free(stacktrace1);
-    free((void *)file_contents);
+    g_free((void *)file_contents);
 }
 
 static void
@@ -224,8 +224,8 @@ test_ruby_stacktrace_to_json(void)
         g_assert_cmpstr(json, ==, expected);
 
         sr_ruby_stacktrace_free(stacktrace1);
-        free(json);
-        free((void *)file_contents);
+        g_free(json);
+        g_free((void *)file_contents);
     }
 }
 
@@ -268,8 +268,8 @@ test_ruby_stacktrace_from_json(void)
 
         sr_ruby_stacktrace_free(stacktrace1);
         sr_ruby_stacktrace_free(stacktrace2);
-        free(json);
-        free((void *)file_contents);
+        g_free(json);
+        g_free((void *)file_contents);
     }
 }
 

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -181,10 +181,10 @@ test_parse_char_span(void)
     g_assert_true(*input == 'c' && strcmp(result, "ab") == 0);
     g_assert_cmpint(0, ==, sr_parse_char_span((const char **)&input, "ba", &result));
     g_assert_true(*input == 'c' && strcmp(result, "ab") == 0);
-    free(result);
+    g_free(result);
     g_assert_cmpint(2, ==, sr_parse_char_span((const char **)&input, "ecfd", &result));
     g_assert_true(*input == '\0' && strcmp(result, "cd") == 0);
-    free(result);
+    g_free(result);
 }
 
 static void
@@ -196,10 +196,10 @@ test_parse_char_cspan(void)
     g_assert_true(*input == 'c' && strcmp(result, "ab") == 0);
     g_assert_false(sr_parse_char_cspan((const char **)&input, "c", &result));
     g_assert_true(*input == 'c' && strcmp(result, "ab") == 0);
-    free(result);
+    g_free(result);
     g_assert_true(sr_parse_char_cspan((const char **)&input, "e", &result));
     g_assert_true(*input == '\0' && strcmp(result, "cd") == 0);
-    free(result);
+    g_free(result);
 }
 
 static void
@@ -221,7 +221,7 @@ test_parse_string(void)
     g_assert_true(sr_parse_string((const char **)&input, "ab", &result));
     g_assert_cmpstr(result, ==, "ab");
     g_assert_cmpint(*input, ==, 'c');
-    free(result);
+    g_free(result);
 }
 
 static void


### PR DESCRIPTION
Replace `free()` with `g_free()` in cases where the memory was allocated with g_malloc() and similar. Note that there are some plain `free()`s left because the memory is allocated e.g. by `asprintf` or `__cxa_demangle`.

See also abrt/abrt#1567

Also, replace a few forgotten malloc()s with g_malloc().