### PR TITLE
py_base_stacktrace.c: include glib.h

### DIFF
--- a/python/py_base_stacktrace.c
+++ b/python/py_base_stacktrace.c
@@ -19,7 +19,6 @@
 */
 #include <glib.h>
 #include "py_common.h"
-#include "py_base_thread.h"
 #include "py_base_stacktrace.h"
 
 #include "stacktrace.h"

--- a/python/py_base_stacktrace.c
+++ b/python/py_base_stacktrace.c
@@ -17,7 +17,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-
+#include <glib.h>
 #include "py_common.h"
 #include "py_base_thread.h"
 #include "py_base_stacktrace.h"


### PR DESCRIPTION
This file has references to g_free from glib-2.0 which needs this header

Signed-off-by: Khem Raj <raj.khem@gmail.com>