### PR TITLE
Add support for fine-grained error location lines in Python tracebacks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 unreleased
 ==========
+Add support for fine-grained error location lines in Python tracebacks
 
 0.39
 ==========

--- a/lib/python_stacktrace.c
+++ b/lib/python_stacktrace.c
@@ -215,27 +215,6 @@ sr_python_stacktrace_parse(const char **input,
         return NULL;
     }
 
-    bool invalid_syntax_pointer = true;
-    const char *tmp_input = local_input;
-    while (*tmp_input != '\n' && *tmp_input != '\0')
-    {
-        if (*tmp_input != ' ' && *tmp_input != '^')
-        {
-            invalid_syntax_pointer = false;
-            break;
-        }
-        ++tmp_input;
-    }
-
-    if (invalid_syntax_pointer)
-    {
-        /* Skip line "   ^" pointing to the invalid code */
-        sr_skip_char_cspan(&local_input, "\n");
-        ++local_input;
-        ++location->line;
-        location->column = 1;
-    }
-
     /* Parse exception name. */
     if (!sr_parse_char_cspan(&local_input, ":\n", &stacktrace->exception_name))
     {

--- a/tests/python/python.py
+++ b/tests/python/python.py
@@ -181,6 +181,22 @@ class TestPythonStacktrace(BindingsTestCase):
         self.assertTrue(f.special_function)
         self.assertFalse(f.special_file)
 
+    def test_fine_grained_error_location(self):
+        trace = load_input_contents('../python_stacktraces/python-06')
+        trace = satyr.PythonStacktrace(trace)
+
+        self.assertEqual(len(trace.frames), 1)
+        self.assertEqual(trace.exception_name, 'ZeroDivisionError')
+
+        f = trace.frames[0]
+        self.assertEqual(f.file_name, '/usr/bin/will_python3_raise')
+        self.assertEqual(f.function_name, "module")
+        self.assertEqual(f.file_line, 3)
+        self.assertEqual(f.line_contents, '0/0')
+        self.assertTrue(f.special_function)
+        self.assertFalse(f.special_file)
+
+
 class TestPythonFrame(BindingsTestCase):
     def setUp(self):
         self.frame = satyr.PythonStacktrace(contents).frames[-1]

--- a/tests/python_stacktraces/python-06
+++ b/tests/python_stacktraces/python-06
@@ -1,0 +1,18 @@
+will_python3_raise:3:<module>:ZeroDivisionError: division by zero
+
+Traceback (most recent call last):
+  File "/usr/bin/will_python3_raise", line 3, in <module>
+    0/0
+    ~^~
+ZeroDivisionError: division by zero
+
+Local variables in innermost frame:
+__name__: '__main__'
+__doc__: None
+__package__: None
+__loader__: <_frozen_importlib_external.SourceFileLoader object at 0x7fd295c62c50>
+__spec__: None
+__annotations__: {}
+__builtins__: <module 'builtins' (built-in)>
+__file__: '/usr/bin/will_python3_raise'
+__cached__: None


### PR DESCRIPTION
See: PEP 657

Python 3.11 makes it easier to identify where on the line a problem occurred. This is achieved with the error location lines. We need to skip such lines when parsing the traceback, otherwise we won't identify the exception name correctly (See: rhbz#2137473).

Example:

Traceback (most recent call last):
  File "test.py", line 2, in <module>
    x['a']['b']['c']['d'] = 1
    ~~~~~~~~~~~^^^^^
TypeError: 'NoneType' object is not subscriptable

Signed-off-by: Michal Srb <michal@redhat.com>