### PR TITLE
Normalize both gdb stacktrace and the crash frame

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 unreleased
 ==========
 
+0.41
+==========
+Normalize both gdb stacktrace and the crash frame (rhbz#2168223)
+
 0.40
 ==========
 Add support for fine-grained error location lines in Python tracebacks

--- a/gen-version
+++ b/gen-version
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEF_VER=0.40
+DEF_VER=0.41
 LF='
 '
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -90,7 +90,7 @@ libsatyr_conv_la_LIBADD = \
 lib_LTLIBRARIES = libsatyr.la
 libsatyr_la_SOURCES = 
 libsatyr_la_LIBADD = libsatyr_conv.la
-libsatyr_la_LDFLAGS = -version-info 4:3:0 -export-symbols-regex '^sr_'
+libsatyr_la_LDFLAGS = -version-info 4:4:0 -export-symbols-regex '^sr_'
 
 # NOTE: when updating CURRENT, update it in ruby/lib/satyr.rb as well!
 

--- a/python/py_gdb_stacktrace.c
+++ b/python/py_gdb_stacktrace.c
@@ -532,7 +532,9 @@ sr_py_gdb_stacktrace_normalize(PyObject *self, PyObject *args)
     Py_DECREF(this->threads);
 
     this->stacktrace->threads = tmp->threads;
+    this->stacktrace->crash = tmp->crash;
     tmp->threads = NULL;
+    tmp->crash = NULL;
     sr_gdb_stacktrace_free(tmp);
 
     this->threads = thread_linked_list_to_python_list(this->stacktrace);

--- a/satyr.spec.in
+++ b/satyr.spec.in
@@ -129,6 +129,10 @@ make check|| {
 %endif
 
 %changelog
+* Sun Feb 19 2023 Michal Srb <michal@redhat.com> 0.41-1
+- Normalize both gdb stacktrace and the crash frame
+- Use SPDX format for license field
+
 * Mon Oct 31 2022 Michal Srb <michal@redhat.com> 0.40-1
 - Add support for fine-grained error location lines in Python tracebacks
 - py_base_stacktrace.c: Avoid duplicate include of py_base_thread.h


### PR DESCRIPTION
If we normalize the stacktrace, then we should also normalize
the crash frame.
Otherwise the normalized function name from the top thread frame
doesn't have to match with the same function name in the crash frame.
    
Example:
Normalized thread frame function name: __poll
Raw crash frame function name: __GI___poll

Resolves: rhbz#2168223

Signed-off-by: Michal Srb <michal@redhat.com>