### PR TITLE
Find crash thread before stacktrace is normalized

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 unreleased
 ==========
 
+0.42
+==========
+Find crash thread before stacktrace is normalized
+
 0.41
 ==========
 Normalize both gdb stacktrace and the crash frame (rhbz#2168223)

--- a/gen-version
+++ b/gen-version
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEF_VER=0.41
+DEF_VER=0.42
 LF='
 '
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -90,7 +90,7 @@ libsatyr_conv_la_LIBADD = \
 lib_LTLIBRARIES = libsatyr.la
 libsatyr_la_SOURCES = 
 libsatyr_la_LIBADD = libsatyr_conv.la
-libsatyr_la_LDFLAGS = -version-info 4:4:0 -export-symbols-regex '^sr_'
+libsatyr_la_LDFLAGS = -version-info 4:5:0 -export-symbols-regex '^sr_'
 
 # NOTE: when updating CURRENT, update it in ruby/lib/satyr.rb as well!
 

--- a/lib/normalize.c
+++ b/lib/normalize.c
@@ -505,6 +505,20 @@ sr_normalize_core_thread(struct sr_core_thread *thread)
 void
 sr_normalize_gdb_stacktrace(struct sr_gdb_stacktrace *stacktrace)
 {
+
+    if (stacktrace->crash_tid == UINT32_MAX)
+    {
+        // We don't have the crash thread id yet and it will be more
+        // difficult to find the crach thread once we normalize the stacktrace.
+        // So let's just look for it now and remember it.
+        struct sr_gdb_thread *crash_thread;
+        crash_thread = sr_gdb_stacktrace_find_crash_thread(stacktrace);
+        if (crash_thread)
+        {
+            stacktrace->crash_tid = crash_thread->tid;
+        }
+    }
+
     struct sr_gdb_thread *thread = stacktrace->threads;
     while (thread)
     {

--- a/python/py_gdb_stacktrace.c
+++ b/python/py_gdb_stacktrace.c
@@ -533,6 +533,7 @@ sr_py_gdb_stacktrace_normalize(PyObject *self, PyObject *args)
 
     this->stacktrace->threads = tmp->threads;
     this->stacktrace->crash = tmp->crash;
+    this->stacktrace->crash_tid = tmp->crash_tid;
     tmp->threads = NULL;
     tmp->crash = NULL;
     sr_gdb_stacktrace_free(tmp);

--- a/satyr.spec.in
+++ b/satyr.spec.in
@@ -129,6 +129,9 @@ make check|| {
 %endif
 
 %changelog
+* Sun Feb 26 2023 Michal Srb <michal@redhat.com> 0.42-1
+- Find crash thread before stacktrace is normalized
+
 * Sun Feb 19 2023 Michal Srb <michal@redhat.com> 0.41-1
 - Normalize both gdb stacktrace and the crash frame
 - Use SPDX format for license field


### PR DESCRIPTION
When we normalize a stacktrace, we sometimes remove certain
frames. The problem is when crash frame is one of those
removed frames. In such cases, we simply cannot (reliably)
find the crash thread.

Therefore, before we normalize the stacktrace, we look
for the crash thread and remember its id. We can then
use that id later, if needed.

Related: rhbz#2168223
Fixes: #337

Signed-off-by: Michal Srb <michal@redhat.com>
