### PR TITLE
Fix test suit core_stacktrace fail using clang

### DIFF
--- a/tests/dump_core.c
+++ b/tests/dump_core.c
@@ -15,7 +15,11 @@
 
 static char const *prefix = "/tmp/satyr.core";
 
+#if __clang__
+__attribute__((optnone))  
+#else
 __attribute__((optimize((0))))
+#endif
 int
 dump_core(int    depth,
           char **name)


### PR DESCRIPTION
Use predefined macros`__clang__` to distinguish between clang and gcc to make sure the correct optimization attribute.